### PR TITLE
Removed incorrect using of String.Format

### DIFF
--- a/EsentCollections/PersistentDictionaryFile.cs
+++ b/EsentCollections/PersistentDictionaryFile.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
                 File.Delete(file);
             }
 
-            foreach (string file in Directory.GetFiles(config.LogFilePath, string.Format(CultureInfo.InvariantCulture, "res*.log", config.BaseName)))
+            foreach (string file in Directory.GetFiles(config.LogFilePath, "res*.log"))
             {
                 File.Delete(file);
             }


### PR DESCRIPTION
"res*.log" string does not have template for config.BaseName. Seems like copy/paste error.
So I suggest to replace the line
`string.Format(CultureInfo.InvariantCulture, "res*.log", config.BaseName)`
just with
`"res*.log"`