### PR TITLE
Simplify if condition, use this.cConditionalColumn > 0 only once

### DIFF
--- a/EsentInterop/jet_indexcreate.cs
+++ b/EsentInterop/jet_indexcreate.cs
@@ -308,8 +308,8 @@ namespace Microsoft.Isam.Esent.Interop
                 throw new ArgumentOutOfRangeException("cbVarSegMac", this.cbVarSegMac, "cannot be negative");
             }
 
-            if ((this.cConditionalColumn > 0 && null == this.rgconditionalcolumn)
-                || (this.cConditionalColumn > 0 && this.cConditionalColumn > this.rgconditionalcolumn.Length))
+            if (this.cConditionalColumn > 0
+                && (null == this.rgconditionalcolumn || this.cConditionalColumn > this.rgconditionalcolumn.Length))
             {
                 throw new ArgumentOutOfRangeException("cConditionalColumn", this.cConditionalColumn, "cannot be greater than the length of rgconditionalcolumn");
             }


### PR DESCRIPTION
Simplified if condition in order to use this.cConditionalColumn > 0 only once in according to DRY principle.