### PR TITLE
Make PersistentDictionary .NET Core 2 compatible

### DIFF
--- a/EsentCollections/PersistentDictionary.cs
+++ b/EsentCollections/PersistentDictionary.cs
@@ -1104,8 +1104,8 @@ namespace Microsoft.Isam.Esent.Collections.Generic
                     throw new InvalidDataException("globals table is empty");
                 }
 
-                Type keyType = (Type)Api.DeserializeObjectFromColumn(session, tableid, keyTypeColumnid);
-                Type valueType = (Type)Api.DeserializeObjectFromColumn(session, tableid, valueTypeColumnid);
+                Type keyType = Type.GetType(Convert.ToString(Api.DeserializeObjectFromColumn(session, tableid, keyTypeColumnid)));
+                Type valueType = Type.GetType(Convert.ToString(Api.DeserializeObjectFromColumn(session, tableid, valueTypeColumnid)));
                 if (keyType != typeof(TKey) || valueType != typeof(TValue))
                 {
                     var error = string.Format(
@@ -1223,8 +1223,8 @@ namespace Microsoft.Isam.Esent.Collections.Generic
 
             using (var update = new Update(session, tableid, JET_prep.Insert))
             {
-                Api.SerializeObjectToColumn(session, tableid, keyTypeColumnid, typeof(TKey));
-                Api.SerializeObjectToColumn(session, tableid, valueTypeColumnid, typeof(TValue));
+                Api.SerializeObjectToColumn(session, tableid, keyTypeColumnid, typeof(TKey).FullName);
+                Api.SerializeObjectToColumn(session, tableid, valueTypeColumnid, typeof(TValue).FullName);
                 Api.SetColumn(session, tableid, versionColumnid, this.schema.Version, Encoding.Unicode);
                 update.Save();
             }


### PR DESCRIPTION
The type 'System.RuntimeType' in assembly 'System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e' is not marked as serializable by design.
Therefore the serialization of TKey und TValue in the PersistentDictionary fail if the ManagedEsent assembly is called from a .NET Standard 2.0 assembly which itself is called from a .NET Core application.
This is mentioned in issue #9.
A workaround is suggested by @ViktorHofer in issue [23213](https://github.com/dotnet/corefx/issues/23213).
This PR implements that workaround.