### PR TITLE
resolved failed test due to localized ArgumentOutOfRangeException message

### DIFF
--- a/EsentCollectionsTests/GenericDictionaryTests.cs
+++ b/EsentCollectionsTests/GenericDictionaryTests.cs
@@ -279,7 +279,8 @@ namespace EsentCollectionsTests
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Assert.AreEqual("Not supported for SetColumn\r\nParameter name: TColumn\r\nActual value was EsentCollectionsTests.GenericDictionaryTests+ContainingStruct.", ex.Message);
+                var expectedMessage = (new ArgumentOutOfRangeException("TColumn", typeof(ContainingStruct), "Not supported for SetColumn")).Message;
+                Assert.AreEqual(expectedMessage, ex.Message);
             }
         }
 

--- a/isam/ColumnAccessor.cs
+++ b/isam/ColumnAccessor.cs
@@ -412,6 +412,11 @@ namespace Microsoft.Database.Isam
                 byte[] bytes = Converter.BytesFromObject(coltyp, isAscii, obj);
                 int bytesLength = bytes == null ? 0 : bytes.Length;
 
+                if ((null != bytes) && (0 == bytes.Length))
+                {
+                    grbitSet |= SetColumnGrbit.ZeroLength;
+                }
+
                 Api.JetSetColumn(this.isamSession.Sesid, this.tableid, columnid, bytes, bytesLength, grbitSet, setinfo);
 
                 this.updateID++;

--- a/isamunittests/IsamDdlTests.cs
+++ b/isamunittests/IsamDdlTests.cs
@@ -291,6 +291,34 @@ namespace IsamUnitTests
         }
 
         /// <summary>
+        /// Insert a single record with emtpy string.
+        /// </summary>
+        [TestMethod]
+        [Priority(2)]
+        [Description("Simple Insertion of empty string.")]
+        public void SimpleInsertionEmptyString()
+        {
+            string tableName = "test4insertionStringEmpty";
+            var tableDefinition = new TableDefinition(tableName);
+            tableDefinition.Columns.Add(new ColumnDefinition("col1") { Type = typeof(string) });
+
+            this.dbid.CreateTable(tableDefinition);
+
+            using (var cursor = this.dbid.OpenCursor(tableName))
+            {
+                cursor.BeginEditForInsert();
+                cursor.EditRecord["col1"] = string.Empty;
+                cursor.AcceptChanges();
+
+                cursor.MoveBeforeFirst();
+                cursor.MoveNext();
+                Assert.AreEqual(string.Empty, cursor.Record["col1"]);
+            }
+
+            this.dbid.DropTable(tableName);
+        }
+
+        /// <summary>
         /// FindRecords(), then MoveNext().
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
The test fails on systems with non EN culture because the text "Actual value was" of ArgumentOutOfRangeException is localized, e. g. on german systems the localized string looks like "Der tatsächliche Wert war".
This change ensures, that the test works independently of the current culture.