### PR TITLE
Resolved failed test due to localized ArgumentOutOfRangeException message

### DIFF
--- a/EsentCollectionsTests/GenericDictionaryTests.cs
+++ b/EsentCollectionsTests/GenericDictionaryTests.cs
@@ -279,7 +279,8 @@ namespace EsentCollectionsTests
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Assert.AreEqual("Not supported for SetColumn\r\nParameter name: TColumn\r\nActual value was EsentCollectionsTests.GenericDictionaryTests+ContainingStruct.", ex.Message);
+                var expectedMessage = (new ArgumentOutOfRangeException("TColumn", typeof(ContainingStruct), "Not supported for SetColumn")).Message;
+                Assert.AreEqual(expectedMessage, ex.Message);
             }
         }
 


### PR DESCRIPTION
The test fails on systems with non EN culture because the text "Actual value was" of ArgumentOutOfRangeException is localized, e. g. on german systems the localized string looks like "Der tatsächliche Wert war".
This change ensures, that the test works independently of the current culture.