### PR TITLE
Fix to save zero length data to column via isam cursor

### DIFF
--- a/isam/ColumnAccessor.cs
+++ b/isam/ColumnAccessor.cs
@@ -412,6 +412,11 @@ namespace Microsoft.Database.Isam
                 byte[] bytes = Converter.BytesFromObject(coltyp, isAscii, obj);
                 int bytesLength = bytes == null ? 0 : bytes.Length;
 
+                if ((null != bytes) && (0 == bytes.Length))
+                {
+                    grbitSet |= SetColumnGrbit.ZeroLength;
+                }
+
                 Api.JetSetColumn(this.isamSession.Sesid, this.tableid, columnid, bytes, bytesLength, grbitSet, setinfo);
 
                 this.updateID++;

--- a/isamunittests/IsamDdlTests.cs
+++ b/isamunittests/IsamDdlTests.cs
@@ -291,6 +291,34 @@ namespace IsamUnitTests
         }
 
         /// <summary>
+        /// Insert a single record with emtpy string.
+        /// </summary>
+        [TestMethod]
+        [Priority(2)]
+        [Description("Simple Insertion of empty string.")]
+        public void SimpleInsertionEmptyString()
+        {
+            string tableName = "test4insertionStringEmpty";
+            var tableDefinition = new TableDefinition(tableName);
+            tableDefinition.Columns.Add(new ColumnDefinition("col1") { Type = typeof(string) });
+
+            this.dbid.CreateTable(tableDefinition);
+
+            using (var cursor = this.dbid.OpenCursor(tableName))
+            {
+                cursor.BeginEditForInsert();
+                cursor.EditRecord["col1"] = string.Empty;
+                cursor.AcceptChanges();
+
+                cursor.MoveBeforeFirst();
+                cursor.MoveNext();
+                Assert.AreEqual(string.Empty, cursor.Record["col1"]);
+            }
+
+            this.dbid.DropTable(tableName);
+        }
+
+        /// <summary>
         /// FindRecords(), then MoveNext().
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
Currently it is not possible to store zero length data via isam cursors because ColumnAccessor.SetColumn does not respect/set SetColumnGrbit.ZeroLength (like  EsentInterop.SetColumnHelpers does). Therefore System.DBNull is returned e. g. in the case if String.Empty is stored to a column.