### PR TITLE
User/mthorp/sync ese 20200110

### DIFF
--- a/EsentCollections/ColumnConverter.cs
+++ b/EsentCollections/ColumnConverter.cs
@@ -102,12 +102,14 @@ namespace Microsoft.Isam.Esent.Collections.Generic
                 this.columnRetriever = CreateRetrieveColumnDelegate();
                 this.coltyp = ColumnTypeMap[underlyingType];
             }
+#if ESENTCOLLECTIONS_SUPPORTS_SERIALIZATION
             else if (IsSerializable(typeof(TColumn)))
             {
                 this.columnSetter = (s, t, c, o) => Api.SerializeObjectToColumn(s, t, c, o);
                 this.columnRetriever = (s, t, c) => (TColumn)Api.DeserializeObjectFromColumn(s, t, c);
                 this.coltyp = JET_coltyp.LongBinary;
             }
+#endif
             else
             {
                 throw new ArgumentOutOfRangeException("TColumn", typeof(TColumn), "Not supported for SetColumn");                    

--- a/EsentCollections/EsentCollections.csproj
+++ b/EsentCollections/EsentCollections.csproj
@@ -1,16 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{CF2D4EE4-0D11-404D-B800-C4DCFEC42588}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EsentCollections</RootNamespace>
     <AssemblyName>Esent.Collections</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <PublicKeyFile>..\scripts\internal\35MSSharedLib1024.snk</PublicKeyFile>
@@ -35,12 +37,14 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
   </PropertyGroup>
+
   <!-- The .snk file won't be published to codeplex. -->
   <PropertyGroup Condition="Exists('$(PublicKeyFile)')">
     <DefineConstants>$(DefineConstants);STRONG_NAMED</DefineConstants>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>$(PublicKeyFile)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -53,6 +57,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -64,18 +69,12 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
+  
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="properties\assemblyinfo.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\EsentInterop\EsentInterop.csproj">
       <Project>{E929E163-52A0-4AAC-917B-6D7FAF70C45E}</Project>
@@ -86,7 +85,7 @@
       <Name>EsentInterop</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EsentCollections/IPersistentDictionaryConfig.cs
+++ b/EsentCollections/IPersistentDictionaryConfig.cs
@@ -68,6 +68,12 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         string KeyTypeColumnName { get; }
 
         /// <summary>
+        /// Gets the name of the key type column in the globals table.
+        /// This column stores the type of the key in the dictionary.
+        /// </summary>
+        string KeyTypeNameColumnName { get; }
+
+        /// <summary>
         /// Gets the name of the value type column in the globals table.
         /// </summary>
         /// <value>
@@ -75,6 +81,12 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// This column stores the type of the value in the dictionary.
         /// </value>
         string ValueTypeColumnName { get; }
+
+        /// <summary>
+        /// Gets the name of the value type name column in the globals table.
+        /// This column stores the name of the type of the value in the dictionary.
+        /// </summary>
+        string ValueTypeNameColumnName { get; }
 
         /// <summary>
         /// Gets the name of the data table.

--- a/EsentCollections/PersistentDictionary.cs
+++ b/EsentCollections/PersistentDictionary.cs
@@ -1120,6 +1120,76 @@ namespace Microsoft.Isam.Esent.Collections.Generic
                 }
 #endif
 
+                var versionColumnid = Api.GetTableColumnid(session, tableid, this.schema.VersionColumnName);
+                bool upgradeNeeded = false;
+
+                JET_COLUMNID keyTypeNameColumnid = JET_COLUMNID.Nil;
+                JET_COLUMNID valueTypeNameColumnid = JET_COLUMNID.Nil;
+
+                // Try to get the columns - if they don't exist this is an old version
+                // and needs an upgrade
+                try
+                {
+                    keyTypeNameColumnid = Api.GetTableColumnid(session, tableid, this.schema.KeyTypeNameColumnName);
+                    valueTypeNameColumnid = Api.GetTableColumnid(session, tableid, this.schema.ValueTypeNameColumnName);
+                }
+                catch (EsentColumnNotFoundException)
+                {
+                    upgradeNeeded = true;
+                }
+
+                if (upgradeNeeded)
+                {
+                    Api.JetAddColumn(
+                        session,
+                        tableid,
+                        this.schema.KeyTypeNameColumnName,
+                        new JET_COLUMNDEF { coltyp = JET_coltyp.LongText },
+                        null,
+                        0,
+                        out keyTypeNameColumnid);
+
+                    Api.JetAddColumn(
+                        session,
+                        tableid,
+                        this.schema.ValueTypeNameColumnName,
+                        new JET_COLUMNDEF { coltyp = JET_coltyp.LongText },
+                        null,
+                        0,
+                        out valueTypeNameColumnid);
+
+                    // Re-establish currency
+                    Api.TryMoveFirst(session, tableid);
+
+                    using (var transaction = new Transaction(session))
+                    using (var update = new Update(session, tableid, JET_prep.Replace))
+                    {
+                        Api.SetColumn(session, tableid, versionColumnid, this.schema.Version, Encoding.Unicode);
+                        Api.SetColumn(session, tableid, keyTypeNameColumnid, typeof(TKey).ToString(), Encoding.Unicode);
+                        Api.SetColumn(session, tableid, valueTypeNameColumnid, typeof(TValue).ToString(), Encoding.Unicode);
+
+                        update.Save();
+                        transaction.Commit(CommitTransactionGrbit.None);
+                    }
+                }
+                else
+                {
+                    string keyTypeName = Api.RetrieveColumnAsString(session, tableid, keyTypeNameColumnid);
+                    string valueTypeName = Api.RetrieveColumnAsString(session, tableid, valueTypeNameColumnid);
+
+                    if (keyTypeName != typeof(TKey).ToString() || valueTypeName != typeof(TValue).ToString())
+                    {
+                        var error = string.Format(
+                            CultureInfo.InvariantCulture,
+                            "Database is of type <{0}, {1}>, not <{2}, {3}>",
+                            keyTypeName,
+                            valueTypeName,
+                            typeof(TKey).ToString(),
+                            typeof(TValue).ToString());
+                        throw new ArgumentException(error);
+                    }
+                }
+
                 Api.JetCloseTable(session, tableid);
 
                 // Data table
@@ -1174,6 +1244,8 @@ namespace Microsoft.Isam.Esent.Collections.Generic
             JET_COLUMNID countColumnid;
             JET_COLUMNID keyTypeColumnid;
             JET_COLUMNID valueTypeColumnid;
+            JET_COLUMNID keyTypeNameColumnid = JET_COLUMNID.Nil;
+            JET_COLUMNID valueTypeNameColumnid = JET_COLUMNID.Nil;
 
             Api.JetCreateTable(session, dbid, this.schema.GlobalsTableName, 1, 100, out tableid);
             Api.JetAddColumn(
@@ -1223,6 +1295,24 @@ namespace Microsoft.Isam.Esent.Collections.Generic
                 0,
                 out valueTypeColumnid);
 
+            Api.JetAddColumn(
+                session,
+                tableid,
+                this.schema.KeyTypeNameColumnName,
+                new JET_COLUMNDEF { coltyp = JET_coltyp.LongText },
+                null,
+                0,
+                out keyTypeNameColumnid);
+
+            Api.JetAddColumn(
+                session,
+                tableid,
+                this.schema.ValueTypeNameColumnName,
+                new JET_COLUMNDEF { coltyp = JET_coltyp.LongText },
+                null,
+                0,
+                out valueTypeNameColumnid);
+
             using (var update = new Update(session, tableid, JET_prep.Insert))
             {
 #if ESENTCOLLECTIONS_SUPPORTS_SERIALIZATION
@@ -1230,6 +1320,9 @@ namespace Microsoft.Isam.Esent.Collections.Generic
                 Api.SerializeObjectToColumn(session, tableid, valueTypeColumnid, typeof(TValue));
 #endif
                 Api.SetColumn(session, tableid, versionColumnid, this.schema.Version, Encoding.Unicode);
+                Api.SetColumn(session, tableid, keyTypeNameColumnid, typeof(TKey).ToString(), Encoding.Unicode);
+                Api.SetColumn(session, tableid, valueTypeNameColumnid, typeof(TValue).ToString(), Encoding.Unicode);
+
                 update.Save();
             }
 

--- a/EsentCollections/PersistentDictionary.cs
+++ b/EsentCollections/PersistentDictionary.cs
@@ -1104,6 +1104,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
                     throw new InvalidDataException("globals table is empty");
                 }
 
+#if ESENTCOLLECTIONS_SUPPORTS_SERIALIZATION
                 Type keyType = (Type)Api.DeserializeObjectFromColumn(session, tableid, keyTypeColumnid);
                 Type valueType = (Type)Api.DeserializeObjectFromColumn(session, tableid, valueTypeColumnid);
                 if (keyType != typeof(TKey) || valueType != typeof(TValue))
@@ -1117,6 +1118,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
                         typeof(TValue));
                     throw new ArgumentException(error);
                 }
+#endif
 
                 Api.JetCloseTable(session, tableid);
 
@@ -1223,8 +1225,10 @@ namespace Microsoft.Isam.Esent.Collections.Generic
 
             using (var update = new Update(session, tableid, JET_prep.Insert))
             {
+#if ESENTCOLLECTIONS_SUPPORTS_SERIALIZATION
                 Api.SerializeObjectToColumn(session, tableid, keyTypeColumnid, typeof(TKey));
                 Api.SerializeObjectToColumn(session, tableid, valueTypeColumnid, typeof(TValue));
+#endif
                 Api.SetColumn(session, tableid, versionColumnid, this.schema.Version, Encoding.Unicode);
                 update.Save();
             }

--- a/EsentCollections/PersistentDictionaryConfig.cs
+++ b/EsentCollections/PersistentDictionaryConfig.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// </summary>
         public string Version
         {
-            get
-            {
-                return "PersistentDictionary 1.0.0";
+            get 
+            { 
+                return "PersistentDictionary 1.1.0"; 
             }
         }
 
@@ -85,6 +85,18 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         }
 
         /// <summary>
+        /// Gets the name of the key type-name column in the globals table.
+        /// This column stores the type of the key in the dictionary.
+        /// </summary>
+        public string KeyTypeNameColumnName
+        {
+            get
+            {
+                return "KeyTypeName";
+            }
+        }
+
+        /// <summary>
         /// Gets the name of the value type column in the globals table.
         /// This column stores the type of the value in the dictionary.
         /// </summary>
@@ -93,6 +105,18 @@ namespace Microsoft.Isam.Esent.Collections.Generic
             get
             {
                 return "ValueType";
+            }
+        }
+
+        /// <summary>
+        /// Gets the name of the value type-name column in the globals table.
+        /// This column stores the name of the type of the value in the dictionary.
+        /// </summary>
+        public string ValueTypeNameColumnName
+        {
+            get
+            {
+                return "ValueTypeName";
             }
         }
 

--- a/EsentCollectionsSamples/HelloWorld/HelloWorld.csproj
+++ b/EsentCollectionsSamples/HelloWorld/HelloWorld.csproj
@@ -1,16 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{8341DE8C-5BC7-461F-B42D-AA2B72586A5C}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HelloWorld</RootNamespace>
     <AssemblyName>HelloWorld</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -18,6 +18,7 @@
     <UpgradeBackupLocation />
     <TargetFrameworkProfile />
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -29,6 +30,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -39,24 +41,12 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="HelloWorld.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\EsentCollections\EsentCollections.csproj">
       <Project>{CF2D4EE4-0D11-404D-B800-C4DCFEC42588}</Project>
@@ -67,10 +57,11 @@
       <Name>EsentInterop</Name>
     </ProjectReference>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="app.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EsentCollectionsSamples/RssDictionarySample/RssDictionarySample.csproj
+++ b/EsentCollectionsSamples/RssDictionarySample/RssDictionarySample.csproj
@@ -1,16 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{134FBC80-2E23-451B-A6B3-72B0AA2234F9}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RssDictionarySample</RootNamespace>
     <AssemblyName>RssDictionarySample</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -18,6 +18,7 @@
     <UpgradeBackupLocation />
     <TargetFrameworkProfile />
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -29,6 +30,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -39,24 +41,12 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
+  
   <ItemGroup>
     <Compile Include="RssDictionarySample.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\EsentCollections\EsentCollections.csproj">
       <Project>{CF2D4EE4-0D11-404D-B800-C4DCFEC42588}</Project>
@@ -67,10 +57,11 @@
       <Name>EsentInterop</Name>
     </ProjectReference>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="app.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EsentCollectionsTests/DictionaryCreationTests.cs
+++ b/EsentCollectionsTests/DictionaryCreationTests.cs
@@ -276,20 +276,23 @@ namespace EsentCollectionsTests
             PersistentDictionaryFile.DeleteFiles(DictionaryLocation);
             Assert.IsFalse(PersistentDictionaryFile.Exists(DictionaryLocation));
             Directory.Delete(DictionaryLocation, false);
-        }
+        }    
 
         /// <summary>
         /// Opening a dictionary fails if the types of the keys don't match.
         /// </summary>
         [TestMethod]
         [Priority(2)]
+#if ESENTCOLLECTIONS_SUPPORTS_SERIALIZATION   
         [ExpectedException(typeof(ArgumentException))]
+#endif
         public void VerifyOpenFailsOnMismatchedKeyTypes()
         {
             const string DictionaryLocation = "IntIntDictionary";
             var dict = new PersistentDictionary<int, int>(DictionaryLocation);
             dict.Dispose();
             var wrongDict = new PersistentDictionary<long, int>(DictionaryLocation);
+            wrongDict.Dispose();
             Cleanup.DeleteDirectoryWithRetry(DictionaryLocation);
         }
 
@@ -298,13 +301,16 @@ namespace EsentCollectionsTests
         /// </summary>
         [TestMethod]
         [Priority(2)]
+#if ESENTCOLLECTIONS_SUPPORTS_SERIALIZATION   
         [ExpectedException(typeof(ArgumentException))]
+#endif
         public void VerifyOpenFailsOnMismatchedValueTypes()
         {
             const string DictionaryLocation = "IntIntDictionary";
             var dict = new PersistentDictionary<int, int>(DictionaryLocation);
             dict.Dispose();
             var wrongDict = new PersistentDictionary<int, string>(DictionaryLocation);
+            wrongDict.Dispose();
             Cleanup.DeleteDirectoryWithRetry(DictionaryLocation);
         }
 

--- a/EsentCollectionsTests/EsentCollectionsTests.csproj
+++ b/EsentCollectionsTests/EsentCollectionsTests.csproj
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EsentCollectionsTests</RootNamespace>
     <AssemblyName>EsentCollectionsTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SignAssembly>true</SignAssembly>
@@ -21,12 +23,14 @@
     <UpgradeBackupLocation />
     <TargetFrameworkProfile />
   </PropertyGroup>
+
   <!-- The .snk file won't be published to codeplex. -->
   <PropertyGroup Condition="Exists('$(PublicKeyFile)')">
     <DefineConstants>$(DefineConstants);STRONG_NAMED</DefineConstants>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>$(PublicKeyFile)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -38,6 +42,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -48,17 +53,19 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\EsentCollections\EsentCollections.csproj">
       <Project>{CF2D4EE4-0D11-404D-B800-C4DCFEC42588}</Project>
@@ -77,7 +84,7 @@
       <Name>EsentInterop</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EsentCollectionsTests/GenericDictionaryTests.cs
+++ b/EsentCollectionsTests/GenericDictionaryTests.cs
@@ -202,6 +202,9 @@ namespace EsentCollectionsTests
         [TestMethod]
         [Priority(3)]
         [Description("Test a String => Decimal dictionary")]
+#if !ESENTCOLLECTIONS_SUPPORTS_SERIALIZATION   
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+#endif
         public void TestGenericStringDecimalDictionary()
         {
             using (var dictionary = new PersistentDictionary<string, decimal?>(DictionaryPath))
@@ -216,6 +219,9 @@ namespace EsentCollectionsTests
         [TestMethod]
         [Priority(3)]
         [Description("Test a String => IPAddress dictionary")]
+#if !ESENTCOLLECTIONS_SUPPORTS_SERIALIZATION   
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+#endif
         public void TestGenericStringIpAddressDictionary()
         {
             using (var dictionary = new PersistentDictionary<string, IPAddress>(DictionaryPath))
@@ -230,6 +236,9 @@ namespace EsentCollectionsTests
         [TestMethod]
         [Priority(3)]
         [Description("Test a String => Uri dictionary")]
+#if !ESENTCOLLECTIONS_SUPPORTS_SERIALIZATION   
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+#endif
         public void TestGenericStringUriDictionary()
         {
             using (var dictionary = new PersistentDictionary<string, Uri>(DictionaryPath))

--- a/EsentCollectionsTests/SerializableStructDictionaryTests.cs
+++ b/EsentCollectionsTests/SerializableStructDictionaryTests.cs
@@ -37,7 +37,6 @@ namespace EsentCollectionsTests
         [TestInitialize]
         public void Setup()
         {
-            this.dictionary = new PersistentDictionary<int, Bar>(DictionaryLocation);
         }
 
         /// <summary>
@@ -46,7 +45,11 @@ namespace EsentCollectionsTests
         [TestCleanup]
         public void Teardown()
         {
-            this.dictionary.Dispose();
+            if (this.dictionary != null)
+            {
+                this.dictionary.Dispose();
+            }
+
             if (Directory.Exists(DictionaryLocation))
             {
                 Cleanup.DeleteDirectoryWithRetry(DictionaryLocation);
@@ -58,8 +61,13 @@ namespace EsentCollectionsTests
         /// </summary>
         [TestMethod]
         [Priority(2)]
+#if !ESENTCOLLECTIONS_SUPPORTS_SERIALIZATION
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+#endif
         public void InsertAndRetrieveSerializableObject()
         {
+            this.dictionary = new PersistentDictionary<int, Bar>(DictionaryLocation);
+
             var expected = new Bar
             {
                 V = new Uri("http://www.microsoft.com"),
@@ -85,8 +93,13 @@ namespace EsentCollectionsTests
         /// </summary>
         [TestMethod]
         [Priority(2)]
+#if !ESENTCOLLECTIONS_SUPPORTS_SERIALIZATION
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+#endif
         public void UpdateSerializableObject()
         {
+            this.dictionary = new PersistentDictionary<int, Bar>(DictionaryLocation);
+
             var expected = new Bar
             {
                 V = new Uri("http://www.contoso.com"),

--- a/EsentInterop/ErrorExceptions.cs
+++ b/EsentInterop/ErrorExceptions.cs
@@ -2220,7 +2220,7 @@ namespace Microsoft.Isam.Esent.Interop
         /// Initializes a new instance of the EsentLogBufferTooSmallException class.
         /// </summary>
         public EsentLogBufferTooSmallException() :
-            base("Log buffer is too small for recovery", JET_err.LogBufferTooSmall)
+            base("An operation generated a log record which was too large to fit in the log buffer or in a single log file", JET_err.LogBufferTooSmall)
         {
         }
 

--- a/EsentInterop/ErrorExceptions.cs
+++ b/EsentInterop/ErrorExceptions.cs
@@ -1868,7 +1868,7 @@ namespace Microsoft.Isam.Esent.Interop
         /// Initializes a new instance of the EsentBackupDirectoryNotEmptyException class.
         /// </summary>
         public EsentBackupDirectoryNotEmptyException() :
-            base("The backup directory is not emtpy", JET_err.BackupDirectoryNotEmpty)
+            base("The backup directory is not empty", JET_err.BackupDirectoryNotEmpty)
         {
         }
 
@@ -2028,7 +2028,7 @@ namespace Microsoft.Isam.Esent.Interop
         /// Initializes a new instance of the EsentLogDisabledDueToRecoveryFailureException class.
         /// </summary>
         public EsentLogDisabledDueToRecoveryFailureException() :
-            base("Try to log something after recovery faild", JET_err.LogDisabledDueToRecoveryFailure)
+            base("Try to log something after recovery failed", JET_err.LogDisabledDueToRecoveryFailure)
         {
         }
 
@@ -7404,7 +7404,7 @@ namespace Microsoft.Isam.Esent.Interop
         /// Initializes a new instance of the EsentSessionWriteConflictException class.
         /// </summary>
         public EsentSessionWriteConflictException() :
-            base("Attempt to replace the same record by two diffrerent cursors in the same session", JET_err.SessionWriteConflict)
+            base("Attempt to replace the same record by two different cursors in the same session", JET_err.SessionWriteConflict)
         {
         }
 
@@ -12332,7 +12332,7 @@ namespace Microsoft.Isam.Esent.Interop
         /// Initializes a new instance of the EsentSessionContextNotSetByThisThreadException class.
         /// </summary>
         public EsentSessionContextNotSetByThisThreadException() :
-            base("Tried to reset session context, but current thread did not orignally set the session context", JET_err.SessionContextNotSetByThisThread)
+            base("Tried to reset session context, but current thread did not originally set the session context", JET_err.SessionContextNotSetByThisThread)
         {
         }
 

--- a/EsentInterop/Esent/EsentStubAttributes.cs
+++ b/EsentInterop/Esent/EsentStubAttributes.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Isam.Esent.Interop
     using System;
     using System.Diagnostics.CodeAnalysis;
 
+#if !MANAGEDESENT_ON_WSA
+This file should only be compiled with MANAGEDESENT_ON_WSA
+#endif
+
     /// <summary>
     /// A fake enumeration to allow compilation on platforms that lack this enumeration.
     /// </summary>

--- a/EsentInterop/EsentException.cs
+++ b/EsentInterop/EsentException.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Isam.Esent
 {
     using System;
     using System.Runtime.Serialization;
-#if !MANAGEDESENT_SUPPORTS_SERIALIZATION
+#if !MANAGEDESENT_SUPPORTS_SERIALIZATION && MANAGEDESENT_ON_WSA
     using Microsoft.Isam.Esent.Interop;
     using SerializableAttribute = Microsoft.Isam.Esent.Interop.SerializableAttribute;
 #endif
@@ -42,7 +42,7 @@ namespace Microsoft.Isam.Esent
         /// <param name="info">The data needed to deserialize the object.</param>
         /// <param name="context">The deserialization context.</param>
         protected EsentException(SerializationInfo info, StreamingContext context)
-#if MANAGEDESENT_SUPPORTS_SERIALIZATION
+#if MANAGEDESENT_SUPPORTS_SERIALIZATION || !MANAGEDESENT_ON_WSA
                 : base(info, context)
 #endif
         {

--- a/EsentInterop/EsentInterop.csproj
+++ b/EsentInterop/EsentInterop.csproj
@@ -11,7 +11,7 @@
     <TargetFrameworks>net462</TargetFrameworks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <DefineConstants>MANAGEDESENT_SUPPORTS_SERIALIZATION</DefineConstants>
+    <DefineConstants></DefineConstants>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <PublicKeyFile>..\scripts\internal\35MSSharedLib1024.snk</PublicKeyFile>

--- a/EsentInterop/EsentInterop.csproj
+++ b/EsentInterop/EsentInterop.csproj
@@ -1,34 +1,29 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{E929E163-52A0-4AAC-917B-6D7FAF70C45E}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Esent.Interop</RootNamespace>
     <AssemblyName>Esent.Interop</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>MANAGEDESENT_SUPPORTS_SERIALIZATION</DefineConstants>
     <FileAlignment>512</FileAlignment>
-    <StartupObject>
-    </StartupObject>
     <SignAssembly>true</SignAssembly>
     <PublicKeyFile>..\scripts\internal\35MSSharedLib1024.snk</PublicKeyFile>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <UpgradeBackupLocation />
-    <TargetFrameworkProfile />
   </PropertyGroup>
+
   <!-- The .snk file won't be published to codeplex. -->
   <PropertyGroup Condition="Exists('$(PublicKeyFile)')">
     <DefineConstants>$(DefineConstants);STRONG_NAMED</DefineConstants>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>$(PublicKeyFile)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -44,6 +39,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -58,9 +54,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="Esent\CallbackDataConverter.cs" />
@@ -68,10 +62,11 @@
     <Compile Include="Esent\EsentNativeMethods.cs" />
     <Compile Include="Esent\AssemblyInfo.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EsentInterop/JetApi.cs
+++ b/EsentInterop/JetApi.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
 #if MANAGEDESENT_ON_WSA
             return this.JetCreateInstance2(out instance, name, null, CreateInstanceGrbit.None);
 #else
-            TraceFunctionCall("JetCreateInstance");
+            TraceFunctionCall();
             instance.Value = IntPtr.Zero;
             if (this.Capabilities.SupportsUnicodePaths)
             {
@@ -144,7 +144,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetCreateInstance2(out JET_INSTANCE instance, string name, string displayName, CreateInstanceGrbit grbit)
         {
-            TraceFunctionCall("JetCreateInstance2");
+            TraceFunctionCall();
             instance.Value = IntPtr.Zero;
 
 #if MANAGEDESENT_ON_WSA
@@ -175,7 +175,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
 #if MANAGEDESENT_ON_WSA
             return this.JetInit3(ref instance, null, InitGrbit.None);
 #else
-            TraceFunctionCall("JetInit");
+            TraceFunctionCall();
             return Err(NativeMethods.JetInit(ref instance.Value));
 #endif // MANAGEDESENT_ON_WSA
         }
@@ -197,7 +197,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
 #if MANAGEDESENT_ON_WSA
             return this.JetInit3(ref instance, null, grbit);
 #else
-            TraceFunctionCall("JetInit2");
+            TraceFunctionCall();
             return Err(NativeMethods.JetInit2(ref instance.Value, (uint)grbit));
 #endif // MANAGEDESENT_ON_WSA
         }
@@ -220,7 +220,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code or warning.</returns>
         public int JetInit3(ref JET_INSTANCE instance, JET_RSTINFO recoveryOptions, InitGrbit grbit)
         {
-            TraceFunctionCall("JetInit3");
+            TraceFunctionCall();
             this.CheckSupportsVistaFeatures("JetInit3");
 
             if (null != recoveryOptions)
@@ -281,7 +281,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetGetInstanceInfo(out int numInstances, out JET_INSTANCE_INFO[] instances)
         {
-            TraceFunctionCall("JetGetInstanceInfo");
+            TraceFunctionCall();
 
             unsafe
             {
@@ -316,7 +316,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetGetInstanceMiscInfo(JET_INSTANCE instance, out JET_SIGNATURE signature, JET_InstanceMiscInfo infoLevel)
         {
-            TraceFunctionCall("JetGetInstanceMiscInfo");
+            TraceFunctionCall();
             this.CheckSupportsVistaFeatures("JetGetInstanceMiscInfo");
 
             var nativeSignature = new NATIVE_SIGNATURE();
@@ -339,7 +339,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code.</returns>
         public int JetStopBackupInstance(JET_INSTANCE instance)
         {
-            TraceFunctionCall("JetStopBackupInstance");
+            TraceFunctionCall();
             return Err(NativeMethods.JetStopBackupInstance(instance.Value));
         }
 
@@ -350,7 +350,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code.</returns>
         public int JetStopServiceInstance(JET_INSTANCE instance)
         {
-            TraceFunctionCall("JetStopServiceInstance");
+            TraceFunctionCall();
             return Err(NativeMethods.JetStopServiceInstance(instance.Value));
         }
 #endif // !MANAGEDESENT_ON_WSA
@@ -365,7 +365,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_INSTANCE instance,
             StopServiceGrbit grbit)
         {
-            TraceFunctionCall("JetStopServiceInstance2");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetStopServiceInstance2");
             return Err(NativeMethods.JetStopServiceInstance2(instance.Value, unchecked((uint)grbit)));
         }
@@ -381,7 +381,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
 #if MANAGEDESENT_ON_WSA
             return this.JetTerm2(instance, TermGrbit.None);
 #else
-            TraceFunctionCall("JetTerm");
+            TraceFunctionCall();
             this.callbackWrappers.Collect();
             if (!instance.IsInvalid)
             {
@@ -401,7 +401,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error or warning.</returns>
         public int JetTerm2(JET_INSTANCE instance, TermGrbit grbit)
         {
-            TraceFunctionCall("JetTerm2");
+            TraceFunctionCall();
             this.callbackWrappers.Collect();
             if (!instance.IsInvalid)
             {
@@ -425,7 +425,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error or warning.</returns>
         public int JetSetSystemParameter(JET_INSTANCE instance, JET_SESID sesid, JET_param paramid, IntPtr paramValue, string paramString)
         {
-            TraceFunctionCall("JetSetSystemParameter");
+            TraceFunctionCall();
             unsafe
             {
                 IntPtr* pinstance = (IntPtr.Zero == instance.Value) ? null : &instance.Value;
@@ -457,7 +457,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error or warning.</returns>
         public int JetSetSystemParameter(JET_INSTANCE instance, JET_SESID sesid, JET_param paramid, JET_CALLBACK paramValue, string paramString)
         {
-            TraceFunctionCall("JetSetSystemParameter");
+            TraceFunctionCall();
 
             unsafe
             {
@@ -528,7 +528,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error or warning.</returns>
         public int JetGetSystemParameter(JET_INSTANCE instance, JET_SESID sesid, JET_param paramid, ref IntPtr paramValue, out string paramString, int maxParam)
         {
-            TraceFunctionCall("JetGetSystemParameter");
+            TraceFunctionCall();
             CheckNotNegative(maxParam, "maxParam");
 
             uint bytesMax = checked((uint)(this.Capabilities.SupportsUnicodePaths ? maxParam * sizeof(char) : maxParam));
@@ -562,7 +562,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetGetVersion(JET_SESID sesid, out uint version)
         {
-            TraceFunctionCall("JetGetVersion");
+            TraceFunctionCall();
             uint nativeVersion;
             int err;
 
@@ -602,7 +602,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
 #if MANAGEDESENT_ON_WSA
             return this.JetCreateDatabase2(sesid, database, 0, out dbid, grbit);
 #else
-            TraceFunctionCall("JetCreateDatabase");
+            TraceFunctionCall();
             CheckNotNull(database, "database");
 
             dbid = JET_DBID.Nil;
@@ -630,7 +630,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error or warning.</returns>
         public int JetCreateDatabase2(JET_SESID sesid, string database, int maxPages, out JET_DBID dbid, CreateDatabaseGrbit grbit)
         {
-            TraceFunctionCall("JetCreateDatabase2");
+            TraceFunctionCall();
             CheckNotNull(database, "database");
             CheckNotNegative(maxPages, "maxPages");
 
@@ -661,7 +661,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
 #if MANAGEDESENT_ON_WSA
             return this.JetAttachDatabase2(sesid, database, 0, grbit);
 #else
-            TraceFunctionCall("JetAttachDatabase");
+            TraceFunctionCall();
             CheckNotNull(database, "database");
 
             if (this.Capabilities.SupportsUnicodePaths)
@@ -688,7 +688,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error or warning.</returns>
         public int JetAttachDatabase2(JET_SESID sesid, string database, int maxPages, AttachDatabaseGrbit grbit)
         {
-            TraceFunctionCall("JetAttachDatabase2");
+            TraceFunctionCall();
             CheckNotNull(database, "database");
             CheckNotNegative(maxPages, "maxPages");
 
@@ -717,7 +717,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error or warning.</returns>
         public int JetOpenDatabase(JET_SESID sesid, string database, string connect, out JET_DBID dbid, OpenDatabaseGrbit grbit)
         {
-            TraceFunctionCall("JetOpenDatabase");
+            TraceFunctionCall();
             CheckNotNull(database, "database");
             dbid = JET_DBID.Nil;
 
@@ -743,7 +743,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error or warning.</returns>
         public int JetCloseDatabase(JET_SESID sesid, JET_DBID dbid, CloseDatabaseGrbit grbit)
         {
-            TraceFunctionCall("JetCloseDatabase");
+            TraceFunctionCall();
             return Err(NativeMethods.JetCloseDatabase(sesid.Value, dbid.Value, (uint)grbit));
         }
 
@@ -755,7 +755,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error or warning.</returns>
         public int JetDetachDatabase(JET_SESID sesid, string database)
         {
-            TraceFunctionCall("JetDetachDatabase");
+            TraceFunctionCall();
 
 #if MANAGEDESENT_ON_WSA
             return this.JetDetachDatabase2(sesid, database, DetachDatabaseGrbit.None);
@@ -778,7 +778,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error or warning.</returns>
         public int JetDetachDatabase2(JET_SESID sesid, string database, DetachDatabaseGrbit grbit)
         {
-            TraceFunctionCall("JetDetachDatabase2");
+            TraceFunctionCall();
 
             if (this.Capabilities.SupportsUnicodePaths)
             {
@@ -821,7 +821,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             object ignored,
             CompactGrbit grbit)
         {
-            TraceFunctionCall("JetCompact");
+            TraceFunctionCall();
             CheckNotNull(sourceDatabase, "sourceDatabase");
             CheckNotNull(destinationDatabase, "destinationDatabase");
             if (null != ignored)
@@ -863,7 +863,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGrowDatabase(JET_SESID sesid, JET_DBID dbid, int desiredPages, out int actualPages)
         {
-            TraceFunctionCall("JetGrowDatabase");
+            TraceFunctionCall();
             CheckNotNegative(desiredPages, "desiredPages");
 
             uint actualPagesNative = 0;
@@ -885,7 +885,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetSetDatabaseSize(JET_SESID sesid, string database, int desiredPages, out int actualPages)
         {
-            TraceFunctionCall("JetSetDatabaseSize");
+            TraceFunctionCall();
             CheckNotNegative(desiredPages, "desiredPages");
             CheckNotNull(database, "database");
 
@@ -921,7 +921,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out int value,
             JET_DbInfo infoLevel)
         {
-            TraceFunctionCall("JetGetDatabaseInfo");
+            TraceFunctionCall();
 #if MANAGEDESENT_ON_WSA
             return Err(NativeMethods.JetGetDatabaseInfoW(sesid.Value, dbid.Value, out value, sizeof(int), (uint)infoLevel));
 #else
@@ -943,7 +943,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out JET_DBINFOMISC dbinfomisc,
             JET_DbInfo infoLevel)
         {
-            TraceFunctionCall("JetGetDatabaseInfo");
+            TraceFunctionCall();
             int err = (int)JET_err.Success;
             dbinfomisc = null;
 
@@ -1021,7 +1021,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out string value,
             JET_DbInfo infoLevel)
         {
-            TraceFunctionCall("JetGetDatabaseInfo");
+            TraceFunctionCall();
             int err;
 
             const int MaxCharacters = 1024;
@@ -1055,7 +1055,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out int value,
             JET_DbInfo infoLevel)
         {
-            TraceFunctionCall("JetGetDatabaseFileInfo");
+            TraceFunctionCall();
             int err;
 
             if (this.Capabilities.SupportsUnicodePaths)
@@ -1087,7 +1087,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out long value,
             JET_DbInfo infoLevel)
         {
-            TraceFunctionCall("JetGetDatabaseFileInfo");
+            TraceFunctionCall();
             int err;
 
             if (this.Capabilities.SupportsUnicodePaths)
@@ -1119,7 +1119,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out JET_DBINFOMISC dbinfomisc,
             JET_DbInfo infoLevel)
         {
-            TraceFunctionCall("JetGetDatabaseFileInfo");
+            TraceFunctionCall();
             int err = (int)JET_err.Success;
             dbinfomisc = null;
 
@@ -1191,7 +1191,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         public int JetBackupInstance(
             JET_INSTANCE instance, string destination, BackupGrbit grbit, JET_PFNSTATUS statusCallback)
         {
-            TraceFunctionCall("JetBackupInstance");
+            TraceFunctionCall();
 
             var callbackWrapper = new StatusCallbackWrapper(statusCallback);
             IntPtr functionPointer = (null == statusCallback) ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(callbackWrapper.NativeCallback);
@@ -1234,7 +1234,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code.</returns>
         public int JetRestoreInstance(JET_INSTANCE instance, string source, string destination, JET_PFNSTATUS statusCallback)
         {
-            TraceFunctionCall("JetRestoreInstance");
+            TraceFunctionCall();
             CheckNotNull(source, "source");
 
             var callbackWrapper = new StatusCallbackWrapper(statusCallback);
@@ -1274,7 +1274,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetOSSnapshotPrepare(out JET_OSSNAPID snapid, SnapshotPrepareGrbit grbit)
         {
-            TraceFunctionCall("JetOSSnapshotPrepare");
+            TraceFunctionCall();
             snapid = JET_OSSNAPID.Nil;
             return Err(NativeMethods.JetOSSnapshotPrepare(out snapid.Value, (uint)grbit));
         }
@@ -1288,7 +1288,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetOSSnapshotPrepareInstance(JET_OSSNAPID snapshot, JET_INSTANCE instance, SnapshotPrepareInstanceGrbit grbit)
         {
-            TraceFunctionCall("JetOSSnapshotPrepareInstance");
+            TraceFunctionCall();
             this.CheckSupportsVistaFeatures("JetOSSnapshotPrepareInstance");
             return Err(NativeMethods.JetOSSnapshotPrepareInstance(snapshot.Value, instance.Value, (uint)grbit));
         }
@@ -1310,7 +1310,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetOSSnapshotFreeze(JET_OSSNAPID snapshot, out int numInstances, out JET_INSTANCE_INFO[] instances, SnapshotFreezeGrbit grbit)
         {
-            TraceFunctionCall("JetOSSnapshotFreeze");
+            TraceFunctionCall();
 
             unsafe
             {
@@ -1349,7 +1349,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out JET_INSTANCE_INFO[] instances,
             SnapshotGetFreezeInfoGrbit grbit)
         {
-            TraceFunctionCall("JetOSSnapshotGetFreezeInfo");
+            TraceFunctionCall();
             this.CheckSupportsVistaFeatures("JetOSSnapshotGetFreezeInfo");
             Debug.Assert(this.Capabilities.SupportsUnicodePaths, "JetOSSnapshotGetFreezeInfo is always Unicode");
 
@@ -1374,7 +1374,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetOSSnapshotThaw(JET_OSSNAPID snapid, SnapshotThawGrbit grbit)
         {
-            TraceFunctionCall("JetOSSnapshotThaw");
+            TraceFunctionCall();
             return Err(NativeMethods.JetOSSnapshotThaw(snapid.Value, (uint)grbit));
         }
 
@@ -1391,7 +1391,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetOSSnapshotTruncateLog(JET_OSSNAPID snapshot, SnapshotTruncateLogGrbit grbit)
         {
-            TraceFunctionCall("JetOSSnapshotTruncateLog");
+            TraceFunctionCall();
             this.CheckSupportsVistaFeatures("JetOSSnapshotTruncateLog");
             return Err(NativeMethods.JetOSSnapshotTruncateLog(snapshot.Value, (uint)grbit));
         }
@@ -1410,7 +1410,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetOSSnapshotTruncateLogInstance(JET_OSSNAPID snapshot, JET_INSTANCE instance, SnapshotTruncateLogGrbit grbit)
         {
-            TraceFunctionCall("JetOSSnapshotTruncateLogInstance");
+            TraceFunctionCall();
             this.CheckSupportsVistaFeatures("JetOSSnapshotTruncateLogInstance");
             return Err(NativeMethods.JetOSSnapshotTruncateLogInstance(snapshot.Value, instance.Value, (uint)grbit));
         }
@@ -1423,7 +1423,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code.</returns>
         public int JetOSSnapshotEnd(JET_OSSNAPID snapid, SnapshotEndGrbit grbit)
         {
-            TraceFunctionCall("JetOSSnapshotEnd");
+            TraceFunctionCall();
             this.CheckSupportsVistaFeatures("JetOSSnapshotEnd");
             return Err(NativeMethods.JetOSSnapshotEnd(snapid.Value, (uint)grbit));
         }
@@ -1437,7 +1437,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code.</returns>
         public int JetOSSnapshotAbort(JET_OSSNAPID snapid, SnapshotAbortGrbit grbit)
         {
-            TraceFunctionCall("JetOSSnapshotAbort");
+            TraceFunctionCall();
             this.CheckSupportsServer2003Features("JetOSSnapshotAbort");
             return Err(NativeMethods.JetOSSnapshotAbort(snapid.Value, (uint)grbit));
         }
@@ -1455,7 +1455,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetBeginExternalBackupInstance(JET_INSTANCE instance, BeginExternalBackupGrbit grbit)
         {
-            TraceFunctionCall("JetBeginExternalBackupInstance");
+            TraceFunctionCall();
             return Err(NativeMethods.JetBeginExternalBackupInstance(instance.Value, (uint)grbit));
         }
 
@@ -1468,7 +1468,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetCloseFileInstance(JET_INSTANCE instance, JET_HANDLE handle)
         {
-            TraceFunctionCall("JetCloseFileInstance");
+            TraceFunctionCall();
             return Err(NativeMethods.JetCloseFileInstance(instance.Value, handle.Value));
         }
 
@@ -1481,7 +1481,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetEndExternalBackupInstance(JET_INSTANCE instance)
         {
-            TraceFunctionCall("JetEndExternalBackupInstance");
+            TraceFunctionCall();
             return Err(NativeMethods.JetEndExternalBackupInstance(instance.Value));
         }
 
@@ -1495,7 +1495,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetEndExternalBackupInstance2(JET_INSTANCE instance, EndExternalBackupGrbit grbit)
         {
-            TraceFunctionCall("JetEndExternalBackupInstance2");
+            TraceFunctionCall();
             return Err(NativeMethods.JetEndExternalBackupInstance2(instance.Value, (uint)grbit));
         }
 
@@ -1529,7 +1529,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetGetAttachInfoInstance(JET_INSTANCE instance, out string files, int maxChars, out int actualChars)
         {
-            TraceFunctionCall("JetGetAttachInfoInstance");
+            TraceFunctionCall();
             CheckNotNegative(maxChars, "maxChars");
 
             // These strings have embedded nulls so we can't use a StringBuilder.
@@ -1584,7 +1584,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetGetLogInfoInstance(JET_INSTANCE instance, out string files, int maxChars, out int actualChars)
         {
-            TraceFunctionCall("JetGetLogInfoInstance");
+            TraceFunctionCall();
             CheckNotNegative(maxChars, "maxChars");
 
             // These strings have embedded nulls so we can't use a StringBuilder.
@@ -1638,7 +1638,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetGetTruncateLogInfoInstance(JET_INSTANCE instance, out string files, int maxChars, out int actualChars)
         {
-            TraceFunctionCall("JetGetTruncateLogInfoInstance");
+            TraceFunctionCall();
             CheckNotNegative(maxChars, "maxChars");
 
             // These strings have embedded nulls so we can't use a StringBuilder.
@@ -1682,7 +1682,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetOpenFileInstance(JET_INSTANCE instance, string file, out JET_HANDLE handle, out long fileSizeLow, out long fileSizeHigh)
         {
-            TraceFunctionCall("JetOpenFileInstance");
+            TraceFunctionCall();
             CheckNotNull(file, "file");
             handle = JET_HANDLE.Nil;
             int err;
@@ -1715,7 +1715,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetReadFileInstance(JET_INSTANCE instance, JET_HANDLE file, byte[] buffer, int bufferSize, out int bytesRead)
         {
-            TraceFunctionCall("JetReadFileInstance");
+            TraceFunctionCall();
             CheckNotNull(buffer, "buffer");
             CheckDataSize(buffer, bufferSize, "bufferSize");
 
@@ -1757,7 +1757,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the call fails.</returns>
         public int JetTruncateLogInstance(JET_INSTANCE instance)
         {
-            TraceFunctionCall("JetTruncateLogInstance");
+            TraceFunctionCall();
             return Err(NativeMethods.JetTruncateLogInstance(instance.Value));
         }
 #endif // !MANAGEDESENT_ON_WSA
@@ -1775,7 +1775,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetBeginSession(JET_INSTANCE instance, out JET_SESID sesid, string username, string password)
         {
-            TraceFunctionCall("JetBeginSession");
+            TraceFunctionCall();
             sesid = JET_SESID.Nil;
 #if MANAGEDESENT_ON_WSA
             return Err(NativeMethods.JetBeginSessionW(instance.Value, out sesid.Value, username, password));
@@ -1795,7 +1795,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetSetSessionContext(JET_SESID sesid, IntPtr context)
         {
-            TraceFunctionCall("JetSetSessionContext");
+            TraceFunctionCall();
             return Err(NativeMethods.JetSetSessionContext(sesid.Value, context));
         }
 
@@ -1807,7 +1807,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetResetSessionContext(JET_SESID sesid)
         {
-            TraceFunctionCall("JetResetSessionContext");
+            TraceFunctionCall();
             return Err(NativeMethods.JetResetSessionContext(sesid.Value));
         }
 
@@ -1819,7 +1819,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetEndSession(JET_SESID sesid, EndSessionGrbit grbit)
         {
-            TraceFunctionCall("JetEndSession");
+            TraceFunctionCall();
             return Err(NativeMethods.JetEndSession(sesid.Value, (uint)grbit));
         }
 
@@ -1832,7 +1832,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetDupSession(JET_SESID sesid, out JET_SESID newSesid)
         {
-            TraceFunctionCall("JetDupSession");
+            TraceFunctionCall();
             newSesid = JET_SESID.Nil;
             return Err(NativeMethods.JetDupSession(sesid.Value, out newSesid.Value));
         }
@@ -1850,7 +1850,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the operation fails.</returns>
         public int JetGetThreadStats(out JET_THREADSTATS threadstats)
         {
-            TraceFunctionCall("JetGetThreadStats");
+            TraceFunctionCall();
             this.CheckSupportsVistaFeatures("JetGetThreadStats");
 
             // To speed up the interop we use unsafe code to avoid initializing
@@ -1881,7 +1881,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetOpenTable(JET_SESID sesid, JET_DBID dbid, string tablename, byte[] parameters, int parametersLength, OpenTableGrbit grbit, out JET_TABLEID tableid)
         {
-            TraceFunctionCall("JetOpenTable");
+            TraceFunctionCall();
             tableid = JET_TABLEID.Nil;
             CheckNotNull(tablename, "tablename");
             CheckDataSize(parameters, parametersLength, "parametersLength");
@@ -1901,7 +1901,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetCloseTable(JET_SESID sesid, JET_TABLEID tableid)
         {
-            TraceFunctionCall("JetCloseTable");
+            TraceFunctionCall();
             return Err(NativeMethods.JetCloseTable(sesid.Value, tableid.Value));
         }
 
@@ -1923,7 +1923,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetDupCursor(JET_SESID sesid, JET_TABLEID tableid, out JET_TABLEID newTableid, DupCursorGrbit grbit)
         {
-            TraceFunctionCall("JetDupCursor");
+            TraceFunctionCall();
             newTableid = JET_TABLEID.Nil;
             return Err(NativeMethods.JetDupCursor(sesid.Value, tableid.Value, out newTableid.Value, (uint)grbit));
         }
@@ -1941,7 +1941,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetComputeStats(JET_SESID sesid, JET_TABLEID tableid)
         {
-            TraceFunctionCall("JetComputeStats");
+            TraceFunctionCall();
             return Err(NativeMethods.JetComputeStats(sesid.Value, tableid.Value));
         }
 
@@ -1961,7 +1961,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetSetLS(JET_SESID sesid, JET_TABLEID tableid, JET_LS ls, LsGrbit grbit)
         {
-            TraceFunctionCall("JetSetLS");
+            TraceFunctionCall();
             return Err(NativeMethods.JetSetLS(sesid.Value, tableid.Value, ls.Value, (uint)grbit));
         }
 
@@ -1980,7 +1980,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGetLS(JET_SESID sesid, JET_TABLEID tableid, out JET_LS ls, LsGrbit grbit)
         {
-            TraceFunctionCall("JetGetLS");
+            TraceFunctionCall();
             IntPtr native;
             int err = NativeMethods.JetGetLS(sesid.Value, tableid.Value, out native, (uint)grbit);
             ls = new JET_LS { Value = native };
@@ -2000,7 +2000,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGetCursorInfo(JET_SESID sesid, JET_TABLEID tableid)
         {
-            TraceFunctionCall("JetGetCursorInfo");
+            TraceFunctionCall();
             return Err(NativeMethods.JetGetCursorInfo(sesid.Value, tableid.Value, IntPtr.Zero, 0, 0));
         }
 #endif // !MANAGEDESENT_ON_WSA
@@ -2017,7 +2017,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetBeginTransaction(JET_SESID sesid)
         {
-            TraceFunctionCall("JetBeginTransaction");
+            TraceFunctionCall();
 #if MANAGEDESENT_ON_WSA
             // 19513 is an arbitrary number.
             return this.JetBeginTransaction3(sesid, 19513, BeginTransactionGrbit.None);
@@ -2035,7 +2035,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetBeginTransaction2(JET_SESID sesid, BeginTransactionGrbit grbit)
         {
-            TraceFunctionCall("JetBeginTransaction2");
+            TraceFunctionCall();
 #if MANAGEDESENT_ON_WSA
             // 33193 is an arbitrary number.
             return this.JetBeginTransaction3(sesid, 33193, BeginTransactionGrbit.None);
@@ -2055,7 +2055,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetCommitTransaction(JET_SESID sesid, CommitTransactionGrbit grbit)
         {
-            TraceFunctionCall("JetCommitTransaction");
+            TraceFunctionCall();
 #if MANAGEDESENT_ON_WSA
             JET_COMMIT_ID commitId;
             return this.JetCommitTransaction2(sesid, grbit, TimeSpan.Zero, out commitId);
@@ -2075,7 +2075,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetRollback(JET_SESID sesid, RollbackTransactionGrbit grbit)
         {
-            TraceFunctionCall("JetRollback");
+            TraceFunctionCall();
             return Err(NativeMethods.JetRollback(sesid.Value, unchecked((uint)grbit)));
         }
 
@@ -2097,7 +2097,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetCreateTable(JET_SESID sesid, JET_DBID dbid, string table, int pages, int density, out JET_TABLEID tableid)
         {
-            TraceFunctionCall("JetCreateTable");
+            TraceFunctionCall();
             tableid = JET_TABLEID.Nil;
             CheckNotNull(table, "table");
 
@@ -2125,7 +2125,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetDeleteTable(JET_SESID sesid, JET_DBID dbid, string table)
         {
-            TraceFunctionCall("JetDeleteTable");
+            TraceFunctionCall();
             CheckNotNull(table, "table");
 
 #if MANAGEDESENT_ON_WSA
@@ -2148,7 +2148,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetAddColumn(JET_SESID sesid, JET_TABLEID tableid, string column, JET_COLUMNDEF columndef, byte[] defaultValue, int defaultValueSize, out JET_COLUMNID columnid)
         {
-            TraceFunctionCall("JetAddColumn");
+            TraceFunctionCall();
             columnid = JET_COLUMNID.Nil;
             CheckNotNull(column, "column");
             CheckNotNull(columndef, "columndef");
@@ -2192,7 +2192,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
 #if MANAGEDESENT_ON_WSA
             return this.JetDeleteColumn2(sesid, tableid, column, DeleteColumnGrbit.None);
 #else
-            TraceFunctionCall("JetDeleteColumn");
+            TraceFunctionCall();
             CheckNotNull(column, "column");
             return Err(NativeMethods.JetDeleteColumn(sesid.Value, tableid.Value, column));
 #endif
@@ -2208,7 +2208,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetDeleteColumn2(JET_SESID sesid, JET_TABLEID tableid, string column, DeleteColumnGrbit grbit)
         {
-            TraceFunctionCall("JetDeleteColumn2");
+            TraceFunctionCall();
             CheckNotNull(column, "column");
 #if MANAGEDESENT_ON_WSA
             return Err(NativeMethods.JetDeleteColumn2W(sesid.Value, tableid.Value, column, (uint)grbit));
@@ -2244,7 +2244,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             int keyDescriptionLength,
             int density)
         {
-            TraceFunctionCall("JetCreateIndex");
+            TraceFunctionCall();
 #if MANAGEDESENT_ON_WSA
             // Up-convert to JetCreateIndex2().
             JET_INDEXCREATE indexcreate = new JET_INDEXCREATE();
@@ -2292,7 +2292,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_INDEXCREATE[] indexcreates,
             int numIndexCreates)
         {
-            TraceFunctionCall("JetCreateIndex2");
+            TraceFunctionCall();
             CheckNotNull(indexcreates, "indexcreates");
             CheckNotNegative(numIndexCreates, "numIndexCreates");
             if (numIndexCreates > indexcreates.Length)
@@ -2337,7 +2337,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetDeleteIndex(JET_SESID sesid, JET_TABLEID tableid, string index)
         {
-            TraceFunctionCall("JetDeleteIndex");
+            TraceFunctionCall();
             CheckNotNull(index, "index");
 
 #if MANAGEDESENT_ON_WSA
@@ -2380,7 +2380,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out JET_TABLEID tableid,
             JET_COLUMNID[] columnids)
         {
-            TraceFunctionCall("JetOpenTempTable");
+            TraceFunctionCall();
             CheckNotNull(columns, "columnns");
             CheckDataSize(columns, numColumns, "numColumns");
             CheckNotNull(columnids, "columnids");
@@ -2443,7 +2443,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out JET_TABLEID tableid,
             JET_COLUMNID[] columnids)
         {
-            TraceFunctionCall("JetOpenTempTable2");
+            TraceFunctionCall();
             CheckNotNull(columns, "columnns");
             CheckDataSize(columns, numColumns, "numColumns");
             CheckNotNull(columnids, "columnids");
@@ -2502,7 +2502,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out JET_TABLEID tableid,
             JET_COLUMNID[] columnids)
         {
-            TraceFunctionCall("JetOpenTempTable3");
+            TraceFunctionCall();
             CheckNotNull(columns, "columnns");
             CheckDataSize(columns, numColumns, "numColumns");
             CheckNotNull(columnids, "columnids");
@@ -2551,7 +2551,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code.</returns>
         public int JetOpenTemporaryTable(JET_SESID sesid, JET_OPENTEMPORARYTABLE temporarytable)
         {
-            TraceFunctionCall("JetOpenTemporaryTable");
+            TraceFunctionCall();
 #if MANAGEDESENT_ON_WSA
             return this.JetOpenTemporaryTable2(sesid, temporarytable);
 #else
@@ -2599,7 +2599,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_DBID dbid,
             JET_TABLECREATE tablecreate)
         {
-            TraceFunctionCall("JetCreateTableColumnIndex3");
+            TraceFunctionCall();
             CheckNotNull(tablecreate, "tablecreate");
 
 #if MANAGEDESENT_ON_WSA
@@ -2630,7 +2630,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
                 string columnName,
                 out JET_COLUMNDEF columndef)
         {
-            TraceFunctionCall("JetGetTableColumnInfo");
+            TraceFunctionCall();
             columndef = new JET_COLUMNDEF();
             CheckNotNull(columnName, "columnName");
 
@@ -2682,7 +2682,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
                 JET_COLUMNID columnid,
                 out JET_COLUMNDEF columndef)
         {
-            TraceFunctionCall("JetGetTableColumnInfo");
+            TraceFunctionCall();
             columndef = new JET_COLUMNDEF();
             int err;
 
@@ -2733,7 +2733,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
                 string columnName,
                 out JET_COLUMNBASE columnbase)
         {
-            TraceFunctionCall("JetGetTableColumnInfo");
+            TraceFunctionCall();
             CheckNotNull(columnName, "columnName");
 
             int err;
@@ -2791,7 +2791,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_COLUMNID columnid,
             out JET_COLUMNBASE columnbase)
         {
-            TraceFunctionCall("JetGetTableColumnInfo");
+            TraceFunctionCall();
             this.CheckSupportsVistaFeatures("JetGetTableColumnInfo");
             int err;
 
@@ -2827,7 +2827,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
                 ColInfoGrbit grbit,
                 out JET_COLUMNLIST columnlist)
         {
-            TraceFunctionCall("JetGetTableColumnInfo");
+            TraceFunctionCall();
             columnlist = new JET_COLUMNLIST();
             int err;
 
@@ -2886,7 +2886,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
                 string columnName,
                 out JET_COLUMNDEF columndef)
         {
-            TraceFunctionCall("JetGetColumnInfo");
+            TraceFunctionCall();
             columndef = new JET_COLUMNDEF();
             CheckNotNull(tablename, "tablename");
             CheckNotNull(columnName, "columnName");
@@ -2945,7 +2945,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
                 string ignored,
                 out JET_COLUMNLIST columnlist)
         {
-            TraceFunctionCall("JetGetColumnInfo");
+            TraceFunctionCall();
             columnlist = new JET_COLUMNLIST();
             CheckNotNull(tablename, "tablename");
             int err;
@@ -3003,7 +3003,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
                 string columnName,
                 out JET_COLUMNBASE columnbase)
         {
-            TraceFunctionCall("JetGetColumnInfo");
+            TraceFunctionCall();
             CheckNotNull(tablename, "tablename");
             CheckNotNull(columnName, "columnName");
             int err;
@@ -3066,7 +3066,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
                 JET_COLUMNID columnid,
                 out JET_COLUMNBASE columnbase)
         {
-            TraceFunctionCall("JetGetColumnInfo");
+            TraceFunctionCall();
             this.CheckSupportsVistaFeatures("JetGetColumnInfo");
             CheckNotNull(tablename, "tablename");
             int err;
@@ -3126,7 +3126,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGetObjectInfo(JET_SESID sesid, JET_DBID dbid, out JET_OBJECTLIST objectlist)
         {
-            TraceFunctionCall("JetGetObjectInfo");
+            TraceFunctionCall();
             objectlist = new JET_OBJECTLIST();
 
             var nativeObjectlist = new NATIVE_OBJECTLIST();
@@ -3182,7 +3182,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             string objectName,
             out JET_OBJECTINFO objectinfo)
         {
-            TraceFunctionCall("JetGetObjectInfo");
+            TraceFunctionCall();
             objectinfo = new JET_OBJECTINFO();
 
             var nativeObjectinfo = new NATIVE_OBJECTINFO();
@@ -3241,7 +3241,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGetCurrentIndex(JET_SESID sesid, JET_TABLEID tableid, out string indexName, int maxNameLength)
         {
-            TraceFunctionCall("JetGetCurrentIndex");
+            TraceFunctionCall();
             CheckNotNegative(maxNameLength, "maxNameLength");
 
             var name = new StringBuilder(maxNameLength);
@@ -3270,7 +3270,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGetTableInfo(JET_SESID sesid, JET_TABLEID tableid, out JET_OBJECTINFO result, JET_TblInfo infoLevel)
         {
-            TraceFunctionCall("JetGetTableInfo");
+            TraceFunctionCall();
             var nativeResult = new NATIVE_OBJECTINFO();
             int err;
 
@@ -3318,7 +3318,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGetTableInfo(JET_SESID sesid, JET_TABLEID tableid, out string result, JET_TblInfo infoLevel)
         {
-            TraceFunctionCall("JetGetTableInfo");
+            TraceFunctionCall();
             var resultBuffer = new StringBuilder(SystemParameters.NameMost + 1);
             int err;
 
@@ -3355,7 +3355,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGetTableInfo(JET_SESID sesid, JET_TABLEID tableid, out JET_DBID result, JET_TblInfo infoLevel)
         {
-            TraceFunctionCall("JetGetTableInfo");
+            TraceFunctionCall();
             result = JET_DBID.Nil;
 
             if (this.Capabilities.SupportsVistaFeatures)
@@ -3386,7 +3386,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGetTableInfo(JET_SESID sesid, JET_TABLEID tableid, int[] result, JET_TblInfo infoLevel)
         {
-            TraceFunctionCall("JetGetTableInfo");
+            TraceFunctionCall();
             CheckNotNull(result, "result");
 
             uint bytesResult = checked((uint)(result.Length * sizeof(int)));
@@ -3418,7 +3418,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGetTableInfo(JET_SESID sesid, JET_TABLEID tableid, out int result, JET_TblInfo infoLevel)
         {
-            TraceFunctionCall("JetGetTableInfo");
+            TraceFunctionCall();
             uint nativeResult;
             int err;
             if (this.Capabilities.SupportsVistaFeatures)
@@ -3461,7 +3461,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out ushort result,
             JET_IdxInfo infoLevel)
         {
-            TraceFunctionCall("JetGetIndexInfo");
+            TraceFunctionCall();
             CheckNotNull(tablename, "tablename");
             int err;
 
@@ -3514,7 +3514,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out int result,
             JET_IdxInfo infoLevel)
         {
-            TraceFunctionCall("JetGetIndexInfo");
+            TraceFunctionCall();
             CheckNotNull(tablename, "tablename");
 
             uint nativeResult;
@@ -3570,7 +3570,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out JET_INDEXID result,
             JET_IdxInfo infoLevel)
         {
-            TraceFunctionCall("JetGetIndexInfo");
+            TraceFunctionCall();
             CheckNotNull(tablename, "tablename");
 
             int err;
@@ -3624,7 +3624,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out JET_INDEXLIST result,
             JET_IdxInfo infoLevel)
         {
-            TraceFunctionCall("JetGetIndexInfo");
+            TraceFunctionCall();
             CheckNotNull(tablename, "tablename");
             int err;
 
@@ -3681,7 +3681,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out string result,
             JET_IdxInfo infoLevel)
         {
-            TraceFunctionCall("JetGetIndexInfo");
+            TraceFunctionCall();
             CheckNotNull(tablename, "tablename");
             int err;
 
@@ -3725,7 +3725,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out ushort result,
             JET_IdxInfo infoLevel)
         {
-            TraceFunctionCall("JetGetTableIndexInfo");
+            TraceFunctionCall();
             int err;
 
             if (this.Capabilities.SupportsVistaFeatures)
@@ -3773,7 +3773,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out int result,
             JET_IdxInfo infoLevel)
         {
-            TraceFunctionCall("JetGetTableIndexInfo");
+            TraceFunctionCall();
 
             uint nativeResult;
             int err;
@@ -3824,7 +3824,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out JET_INDEXID result,
             JET_IdxInfo infoLevel)
         {
-            TraceFunctionCall("JetGetTableIndexInfo");
+            TraceFunctionCall();
             int err;
 
             if (this.Capabilities.SupportsVistaFeatures)
@@ -3872,7 +3872,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out JET_INDEXLIST result,
             JET_IdxInfo infoLevel)
         {
-            TraceFunctionCall("JetGetTableIndexInfo");
+            TraceFunctionCall();
 
             var nativeIndexlist = new NATIVE_INDEXLIST();
             nativeIndexlist.cbStruct = checked((uint)Marshal.SizeOf(typeof(NATIVE_INDEXLIST)));
@@ -3925,7 +3925,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out string result,
             JET_IdxInfo infoLevel)
         {
-            TraceFunctionCall("JetGetTableIndexInfo");
+            TraceFunctionCall();
 
             // Will need to check for Windows 8 Features.
             //
@@ -3959,7 +3959,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetRenameTable(JET_SESID sesid, JET_DBID dbid, string tableName, string newTableName)
         {
-            TraceFunctionCall("JetRenameTable");
+            TraceFunctionCall();
             CheckNotNull(tableName, "tableName");
             CheckNotNull(newTableName, "newTableName");
 #if MANAGEDESENT_ON_WSA
@@ -3980,7 +3980,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetRenameColumn(JET_SESID sesid, JET_TABLEID tableid, string name, string newName, RenameColumnGrbit grbit)
         {
-            TraceFunctionCall("JetRenameColumn");
+            TraceFunctionCall();
             CheckNotNull(name, "name");
             CheckNotNull(newName, "newName");
 #if MANAGEDESENT_ON_WSA
@@ -4007,7 +4007,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         public int JetSetColumnDefaultValue(
             JET_SESID sesid, JET_DBID dbid, string tableName, string columnName, byte[] data, int dataSize, SetColumnDefaultValueGrbit grbit)
         {
-            TraceFunctionCall("JetSetColumnDefaultValue");
+            TraceFunctionCall();
             CheckNotNull(tableName, "tableName");
             CheckNotNull(columnName, "columnName");
             CheckDataSize(data, dataSize, "dataSize");
@@ -4032,7 +4032,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <param name="bookmarkSize">The size of the bookmark.</param>        /// <returns>An error if the call fails.</returns>
         public int JetGotoBookmark(JET_SESID sesid, JET_TABLEID tableid, byte[] bookmark, int bookmarkSize)
         {
-            TraceFunctionCall("JetGotoBookmark");
+            TraceFunctionCall();
             CheckNotNull(bookmark, "bookmark");
             CheckDataSize(bookmark, bookmarkSize, "bookmarkSize");
 
@@ -4066,7 +4066,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             int primaryKeySize,
             GotoSecondaryIndexBookmarkGrbit grbit)
         {
-            TraceFunctionCall("JetGotoSecondaryIndexBookmark");
+            TraceFunctionCall();
             CheckNotNull(secondaryKey, "secondaryKey");
             CheckDataSize(secondaryKey, secondaryKeySize, "secondaryKeySize");
             CheckDataSize(primaryKey, primaryKeySize, "primaryKeySize");
@@ -4097,7 +4097,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetMakeKey(JET_SESID sesid, JET_TABLEID tableid, IntPtr data, int dataSize, MakeKeyGrbit grbit)
         {
-            TraceFunctionCall("JetMakeKey");
+            TraceFunctionCall();
             CheckNotNegative(dataSize, "dataSize");
             return Err(NativeMethods.JetMakeKey(sesid.Value, tableid.Value, data, checked((uint)dataSize), unchecked((uint)grbit)));
         }
@@ -4114,7 +4114,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error or warning..</returns>
         public int JetSeek(JET_SESID sesid, JET_TABLEID tableid, SeekGrbit grbit)
         {
-            TraceFunctionCall("JetSeek");
+            TraceFunctionCall();
             return Err(NativeMethods.JetSeek(sesid.Value, tableid.Value, unchecked((uint)grbit)));
         }
 
@@ -4130,7 +4130,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetMove(JET_SESID sesid, JET_TABLEID tableid, int numRows, MoveGrbit grbit)
         {
-            TraceFunctionCall("JetMove");
+            TraceFunctionCall();
             return Err(NativeMethods.JetMove(sesid.Value, tableid.Value, numRows, unchecked((uint)grbit)));
         }
 
@@ -4148,7 +4148,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetSetIndexRange(JET_SESID sesid, JET_TABLEID tableid, SetIndexRangeGrbit grbit)
         {
-            TraceFunctionCall("JetSetIndexRange");
+            TraceFunctionCall();
             return Err(NativeMethods.JetSetIndexRange(sesid.Value, tableid.Value, unchecked((uint)grbit)));
         }
 
@@ -4177,7 +4177,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out JET_RECORDLIST recordlist,
             IntersectIndexesGrbit grbit)
         {
-            TraceFunctionCall("JetIntersectIndexes");
+            TraceFunctionCall();
             CheckNotNull(ranges, "ranges");
             CheckDataSize(ranges, numRanges, "numRanges");
             if (numRanges < 2)
@@ -4222,7 +4222,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
 #if MANAGEDESENT_ON_WSA
             return this.JetSetCurrentIndex4(sesid, tableid, index, IntPtr.Zero, SetCurrentIndexGrbit.MoveFirst, 1);
 #else
-            TraceFunctionCall("JetSetCurrentIndex");
+            TraceFunctionCall();
 
             // A null index name is valid here -- it will set the table to the primary index
             return Err(NativeMethods.JetSetCurrentIndex(sesid.Value, tableid.Value, index));
@@ -4247,7 +4247,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
 #if MANAGEDESENT_ON_WSA
             return this.JetSetCurrentIndex4(sesid, tableid, index, IntPtr.Zero, grbit, 1);
 #else
-            TraceFunctionCall("JetSetCurrentIndex2");
+            TraceFunctionCall();
 
             // A null index name is valid here -- it will set the table to the primary index
             return Err(NativeMethods.JetSetCurrentIndex2(sesid.Value, tableid.Value, index, (uint)grbit));
@@ -4279,7 +4279,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
 #if MANAGEDESENT_ON_WSA
             return this.JetSetCurrentIndex4(sesid, tableid, index, IntPtr.Zero, grbit, itagSequence);
 #else
-            TraceFunctionCall("JetSetCurrentIndex3");
+            TraceFunctionCall();
 
             // A null index name is valid here -- it will set the table to the primary index
             return Err(NativeMethods.JetSetCurrentIndex3(sesid.Value, tableid.Value, index, (uint)grbit, checked((uint)itagSequence)));
@@ -4318,7 +4318,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             SetCurrentIndexGrbit grbit,
             int itagSequence)
         {
-            TraceFunctionCall("JetSetCurrentIndex4");
+            TraceFunctionCall();
 
             // A null index name is valid here -- it will set the table to the primary index
 #if MANAGEDESENT_ON_WSA
@@ -4344,7 +4344,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetIndexRecordCount(JET_SESID sesid, JET_TABLEID tableid, out int numRecords, int maxRecordsToCount)
         {
-            TraceFunctionCall("JetIndexRecordCount");
+            TraceFunctionCall();
             CheckNotNegative(maxRecordsToCount, "maxRecordsToCount");
             uint crec = 0;
             int err = Err(NativeMethods.JetIndexRecordCount(sesid.Value, tableid.Value, out crec, unchecked((uint)maxRecordsToCount))); // -1 is allowed
@@ -4368,7 +4368,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetIndexRecordCount2(JET_SESID sesid, JET_TABLEID tableid, out long numRecords, long maxRecordsToCount)
         {
-            TraceFunctionCall("JetIndexRecordCount2");
+            TraceFunctionCall();
             CheckNotNegative(maxRecordsToCount, "maxRecordsToCount");
             ulong crec = 0;
             int err = Err(NativeMethods.JetIndexRecordCount2(sesid.Value, tableid.Value, out crec, unchecked((ulong)maxRecordsToCount)));
@@ -4388,7 +4388,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetSetTableSequential(JET_SESID sesid, JET_TABLEID tableid, SetTableSequentialGrbit grbit)
         {
-            TraceFunctionCall("JetSetTableSequential");
+            TraceFunctionCall();
             return Err(NativeMethods.JetSetTableSequential(sesid.Value, tableid.Value, (uint)grbit));
         }
 
@@ -4403,7 +4403,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetResetTableSequential(JET_SESID sesid, JET_TABLEID tableid, ResetTableSequentialGrbit grbit)
         {
-            TraceFunctionCall("JetResetTableSequential");
+            TraceFunctionCall();
             return Err(NativeMethods.JetResetTableSequential(sesid.Value, tableid.Value, (uint)grbit));
         }
 
@@ -4417,7 +4417,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGetRecordPosition(JET_SESID sesid, JET_TABLEID tableid, out JET_RECPOS recpos)
         {
-            TraceFunctionCall("JetGetRecordPosition");
+            TraceFunctionCall();
             recpos = new JET_RECPOS();
             NATIVE_RECPOS native = recpos.GetNativeRecpos();
             int err = Err(NativeMethods.JetGetRecordPosition(sesid.Value, tableid.Value, out native, native.cbStruct));
@@ -4435,7 +4435,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGotoPosition(JET_SESID sesid, JET_TABLEID tableid, JET_RECPOS recpos)
         {
-            TraceFunctionCall("JetGotoPosition");
+            TraceFunctionCall();
             NATIVE_RECPOS native = recpos.GetNativeRecpos();
             return Err(NativeMethods.JetGotoPosition(sesid.Value, tableid.Value, ref native));
         }
@@ -4474,7 +4474,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out int keysPreread,
             PrereadKeysGrbit grbit)
         {
-            TraceFunctionCall("JetPrereadKeys");
+            TraceFunctionCall();
             this.CheckSupportsWindows7Features("JetPrereadKeys");
             CheckDataSize(keys, keyIndex, "keyIndex", keyCount, "keyCount");
             CheckDataSize(keyLengths, keyIndex, "keyIndex", keyCount, "keyCount");
@@ -4523,7 +4523,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGetBookmark(JET_SESID sesid, JET_TABLEID tableid, byte[] bookmark, int bookmarkSize, out int actualBookmarkSize)
         {
-            TraceFunctionCall("JetGetBookmark");
+            TraceFunctionCall();
             CheckDataSize(bookmark, bookmarkSize, "bookmarkSize");
 
             uint bytesActual = 0;
@@ -4568,7 +4568,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out int actualPrimaryKeySize,
             GetSecondaryIndexBookmarkGrbit grbit)
         {
-            TraceFunctionCall("JetGetSecondaryIndexBookmark");
+            TraceFunctionCall();
             CheckDataSize(secondaryKey, secondaryKeySize, "secondaryKeySize");
             CheckDataSize(primaryKey, primaryKeySize, "primaryKeySize");
 
@@ -4604,7 +4604,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetRetrieveKey(JET_SESID sesid, JET_TABLEID tableid, byte[] data, int dataSize, out int actualDataSize, RetrieveKeyGrbit grbit)
         {
-            TraceFunctionCall("JetRetrieveKey");
+            TraceFunctionCall();
             CheckDataSize(data, dataSize, "dataSize");
 
             uint bytesActual = 0;
@@ -4643,7 +4643,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error or warning.</returns>
         public int JetRetrieveColumn(JET_SESID sesid, JET_TABLEID tableid, JET_COLUMNID columnid, IntPtr data, int dataSize, out int actualDataSize, RetrieveColumnGrbit grbit, JET_RETINFO retinfo)
         {
-            TraceFunctionCall("JetRetrieveColumn");
+            TraceFunctionCall();
             CheckNotNegative(dataSize, "dataSize");
 
             int err;
@@ -4701,7 +4701,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// </returns>
         public unsafe int JetRetrieveColumns(JET_SESID sesid, JET_TABLEID tableid, NATIVE_RETRIEVECOLUMN* retrievecolumns, int numColumns)
         {
-            TraceFunctionCall("JetRetrieveColumns");
+            TraceFunctionCall();
             return Err(NativeMethods.JetRetrieveColumns(sesid.Value, tableid.Value, retrievecolumns, checked((uint)numColumns)));
         }
 
@@ -4759,7 +4759,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             int maxDataSize,
             EnumerateColumnsGrbit grbit)
         {
-            TraceFunctionCall("JetEnumerateColumns");
+            TraceFunctionCall();
             CheckNotNull(allocator, "allocator");
             CheckNotNegative(maxDataSize, "maxDataSize");
             CheckDataSize(columnids, numColumnids, "numColumnids");
@@ -4941,7 +4941,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>A warning, error or success.</returns>
         public int JetGetRecordSize(JET_SESID sesid, JET_TABLEID tableid, ref JET_RECSIZE recsize, GetRecordSizeGrbit grbit)
         {
-            TraceFunctionCall("JetGetRecordSize");
+            TraceFunctionCall();
             this.CheckSupportsVistaFeatures("JetGetRecordSize");
             int err;
 
@@ -4975,7 +4975,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetDelete(JET_SESID sesid, JET_TABLEID tableid)
         {
-            TraceFunctionCall("JetDelete");
+            TraceFunctionCall();
             return Err(NativeMethods.JetDelete(sesid.Value, tableid.Value));
         }
 
@@ -4988,7 +4988,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetPrepareUpdate(JET_SESID sesid, JET_TABLEID tableid, JET_prep prep)
         {
-            TraceFunctionCall("JetPrepareUpdate");
+            TraceFunctionCall();
             return Err(NativeMethods.JetPrepareUpdate(sesid.Value, tableid.Value, unchecked((uint)prep)));
         }
 
@@ -5012,7 +5012,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetUpdate(JET_SESID sesid, JET_TABLEID tableid, byte[] bookmark, int bookmarkSize, out int actualBookmarkSize)
         {
-            TraceFunctionCall("JetUpdate");
+            TraceFunctionCall();
 #if MANAGEDESENT_ON_WSA
             return this.JetUpdate2(sesid, tableid, bookmark, bookmarkSize, out actualBookmarkSize, UpdateGrbit.None);
 #else
@@ -5046,7 +5046,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetUpdate2(JET_SESID sesid, JET_TABLEID tableid, byte[] bookmark, int bookmarkSize, out int actualBookmarkSize, UpdateGrbit grbit)
         {
-            TraceFunctionCall("JetUpdate2");
+            TraceFunctionCall();
             CheckDataSize(bookmark, bookmarkSize, "bookmarkSize");
             this.CheckSupportsServer2003Features("JetUpdate2");
 
@@ -5077,7 +5077,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetSetColumn(JET_SESID sesid, JET_TABLEID tableid, JET_COLUMNID columnid, IntPtr data, int dataSize, SetColumnGrbit grbit, JET_SETINFO setinfo)
         {
-            TraceFunctionCall("JetSetColumn");
+            TraceFunctionCall();
             CheckNotNegative(dataSize, "dataSize");
             if (IntPtr.Zero == data)
             {
@@ -5117,7 +5117,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code or warning.</returns>
         public unsafe int JetSetColumns(JET_SESID sesid, JET_TABLEID tableid, NATIVE_SETCOLUMN* setcolumns, int numColumns)
         {
-            TraceFunctionCall("JetSetColumns");
+            TraceFunctionCall();
             return Err(NativeMethods.JetSetColumns(sesid.Value, tableid.Value, setcolumns, checked((uint)numColumns)));
         }
 
@@ -5135,7 +5135,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetGetLock(JET_SESID sesid, JET_TABLEID tableid, GetLockGrbit grbit)
         {
-            TraceFunctionCall("JetGetLock");
+            TraceFunctionCall();
             return Err(NativeMethods.JetGetLock(sesid.Value, tableid.Value, unchecked((uint)grbit)));
         }
 #endif // !MANAGEDESENT_ON_WSA
@@ -5170,7 +5170,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out int actualPreviousValueLength,
             EscrowUpdateGrbit grbit)
         {
-            TraceFunctionCall("JetEscrowUpdate");
+            TraceFunctionCall();
             CheckNotNull(delta, "delta");
             CheckDataSize(delta, deltaSize, "deltaSize");
             CheckDataSize(previousValue, previousValueLength, "previousValueLength");
@@ -5224,7 +5224,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             IntPtr context,
             out JET_HANDLE callbackId)
         {
-            TraceFunctionCall("JetRegisterCallback");
+            TraceFunctionCall();
             CheckNotNull(callback, "callback");
 
             callbackId = JET_HANDLE.Nil;
@@ -5256,7 +5256,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetUnregisterCallback(JET_SESID sesid, JET_TABLEID tableid, JET_cbtyp cbtyp, JET_HANDLE callbackId)
         {
-            TraceFunctionCall("JetUnregisterCallback");
+            TraceFunctionCall();
             this.callbackWrappers.Collect();
             return Err(NativeMethods.JetUnregisterCallback(
                 sesid.Value,
@@ -5300,7 +5300,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
 #if MANAGEDESENT_ON_WSA
             return this.JetDefragment2(sesid, dbid, tableName, ref passes, ref seconds, null, grbit);
 #else
-            TraceFunctionCall("JetDefragment");
+            TraceFunctionCall();
             uint nativePasses = unchecked((uint)passes);
             uint nativeSeconds = unchecked((uint)seconds);
             int err = Err(NativeMethods.JetDefragment(
@@ -5334,7 +5334,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
 #if MANAGEDESENT_ON_WSA
             return this.Defragment2(sesid, dbid, tableName, null, grbit);
 #else
-            TraceFunctionCall("Defragment");
+            TraceFunctionCall();
             int err = Err(NativeMethods.JetDefragment(
                 sesid.Value, dbid.Value, tableName, IntPtr.Zero, IntPtr.Zero, (uint)grbit));
             return err;
@@ -5376,7 +5376,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_CALLBACK callback,
             DefragGrbit grbit)
         {
-            TraceFunctionCall("JetDefragment2");
+            TraceFunctionCall();
             uint nativePasses = unchecked((uint)passes);
             uint nativeSeconds = unchecked((uint)seconds);
 
@@ -5431,7 +5431,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_CALLBACK callback,
             DefragGrbit grbit)
         {
-            TraceFunctionCall("Defragment2");
+            TraceFunctionCall();
 
             IntPtr functionPointer;
             if (null == callback)
@@ -5468,7 +5468,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the operation fails.</returns>
         public int JetIdle(JET_SESID sesid, IdleGrbit grbit)
         {
-            TraceFunctionCall("JetIdle");
+            TraceFunctionCall();
             return Err(NativeMethods.JetIdle(sesid.Value, (uint)grbit));
         }
 #endif // !MANAGEDESENT_ON_WSA
@@ -5485,7 +5485,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code.</returns>
         public int JetConfigureProcessForCrashDump(CrashDumpGrbit grbit)
         {
-            TraceFunctionCall("JetConfigureProcessForCrashDump");
+            TraceFunctionCall();
             this.CheckSupportsWindows7Features("JetConfigureProcessForCrashDump");
             return Err(NativeMethods.JetConfigureProcessForCrashDump((uint)grbit));
         }
@@ -5500,7 +5500,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code.</returns>
         public int JetFreeBuffer(IntPtr buffer)
         {
-            TraceFunctionCall("JetFreeBuffer");
+            TraceFunctionCall();
             return Err(NativeMethods.JetFreeBuffer(buffer));
         }
 #endif // !MANAGEDESENT_ON_WSA
@@ -5633,17 +5633,8 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         // Disallow inlining so we can always get the name of the calling function.
         [MethodImpl(MethodImplOptions.NoInlining)]
 #endif
-        private static void TraceFunctionCall(string function)
+        private static void TraceFunctionCall([System.Runtime.CompilerServices.CallerMemberName] string function = null)
         {
-#if DEBUG && !MANAGEDESENT_ON_WSA
-            // Make sure the name of the calling function is correct.
-            var stackTrace = new StackTrace();
-            Debug.Assert(
-                stackTrace.GetFrame(1).GetMethod().Name == function,
-                "Incorrect function name",
-                function);
-#endif // DEBUG && !MANAGEDESENT_ON_WSA
-
             Trace.WriteLineIf(TraceSwitch.TraceInfo, function);
         }
 
@@ -6315,7 +6306,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             SetCurrentIndexGrbit grbit,
             int itagSequence)
         {
-            TraceFunctionCall("JetSetCurrentIndex4");
+            TraceFunctionCall();
 
             if (indexid != IntPtr.Zero)
             {

--- a/EsentInterop/Windows10JetApi.cs
+++ b/EsentInterop/Windows10JetApi.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_sesparam sesparamid,
             out JET_OPERATIONCONTEXT operationContext)
         {
-            TraceFunctionCall("JetGetSessionParameter");
+            TraceFunctionCall();
             this.CheckSupportsWindows10Features("JetGetSessionParameter");
             int err;
             int actualDataSize;
@@ -77,7 +77,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_sesparam sesparamid,
             JET_OPERATIONCONTEXT operationContext)
         {
-            TraceFunctionCall("JetSetSessionParameter");
+            TraceFunctionCall();
             this.CheckSupportsWindows10Features("JetSetSessionParameter");
             int err;
 
@@ -108,7 +108,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code if the operation fails.</returns>
         public int JetGetThreadStats(out JET_THREADSTATS2 threadstats)
         {
-            TraceFunctionCall("JetGetThreadStats");
+            TraceFunctionCall();
             this.CheckSupportsVistaFeatures("JetGetThreadStats");
 
             // To speed up the interop we use unsafe code to avoid initializing

--- a/EsentInterop/Windows8JetApi.cs
+++ b/EsentInterop/Windows8JetApi.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetBeginTransaction3(JET_SESID sesid, long userTransactionId, BeginTransactionGrbit grbit)
         {
-            TraceFunctionCall("JetBeginTransaction3");
+            TraceFunctionCall();
             return Err(NativeMethods.JetBeginTransaction3(sesid.Value, userTransactionId, unchecked((uint)grbit)));
         }
 
@@ -47,7 +47,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetCommitTransaction2(JET_SESID sesid, CommitTransactionGrbit grbit, TimeSpan durableCommit, out JET_COMMIT_ID commitId)
         {
-            TraceFunctionCall("JetCommitTransaction2");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetCommitTransaction2");
             int err;
             uint cmsecDurableCommit = (uint)durableCommit.TotalMilliseconds;
@@ -75,7 +75,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_err error,
             out JET_ERRINFOBASIC errinfo)
         {
-            TraceFunctionCall("JetGetErrorInfo");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetGetErrorInfo");
 
             NATIVE_ERRINFOBASIC nativeErrinfobasic = new NATIVE_ERRINFOBASIC();
@@ -111,7 +111,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out int actualPages,
             ResizeDatabaseGrbit grbit)
         {
-            TraceFunctionCall("JetResizeDatabase");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetResizeDatabase");
             CheckNotNegative(desiredPages, "desiredPages");
 
@@ -147,7 +147,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_INDEXCREATE[] indexcreates,
             int numIndexCreates)
         {
-            TraceFunctionCall("JetCreateIndex4");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetCreateIndex4");
             CheckNotNull(indexcreates, "indexcreates");
             CheckNotNegative(numIndexCreates, "numIndexCreates");
@@ -177,7 +177,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error code.</returns>
         public int JetOpenTemporaryTable2(JET_SESID sesid, JET_OPENTEMPORARYTABLE temporarytable)
         {
-            TraceFunctionCall("JetOpenTemporaryTable2");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetOpenTemporaryTable2");
             CheckNotNull(temporarytable, "temporarytable");
 
@@ -222,7 +222,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_DBID dbid,
             JET_TABLECREATE tablecreate)
         {
-            TraceFunctionCall("JetCreateTableColumnIndex4");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetCreateTableColumnIndex4");
             CheckNotNull(tablecreate, "tablecreate");
 
@@ -244,7 +244,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_sesparam sesparamid,
             out int value)
         {
-            TraceFunctionCall("JetGetSessionParameter");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetGetSessionParameter");
             int err;
 
@@ -290,7 +290,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             int length,
             out int actualDataSize)
         {
-            TraceFunctionCall("JetGetSessionParameter");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetGetSessionParameter");
             CheckDataSize(data, length, "length");
 
@@ -318,7 +318,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_sesparam sesparamid,
             int valueToSet)
         {
-            TraceFunctionCall("JetSetSessionParameter");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetSetSessionParameter");
             int err;
 
@@ -341,7 +341,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             byte[] data,
             int dataSize)
         {
-            TraceFunctionCall("JetSetSessionParameter");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetSetSessionParameter");
             CheckNotNegative(dataSize, "dataSize");
             CheckDataSize(data, dataSize, "dataSize");
@@ -374,7 +374,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out JET_INDEXCREATE result,
             JET_IdxInfo infoLevel)
         {
-            TraceFunctionCall("JetGetIndexInfo");
+            TraceFunctionCall();
             CheckNotNull(tablename, "tablename");
             int err;
 
@@ -444,7 +444,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             out JET_INDEXCREATE result,
             JET_IdxInfo infoLevel)
         {
-            TraceFunctionCall("JetGetTableIndexInfo");
+            TraceFunctionCall();
             int err;
 
             switch (infoLevel)
@@ -524,7 +524,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_COLUMNID[] columnsPreread,
             PrereadIndexRangesGrbit grbit)
         {
-            TraceFunctionCall("JetPrereadIndexRanges");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetPrereadIndexRanges");
             CheckNotNull(indexRanges, "indexRanges");
             CheckDataSize(indexRanges, rangeIndex, "rangeIndex", rangeCount, "rangeCount");
@@ -589,7 +589,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
             JET_COLUMNID[] columnsPreread,
             PrereadIndexRangesGrbit grbit)
         {
-            TraceFunctionCall("JetPrereadKeyRanges");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetPrereadKeyRanges");
             CheckDataSize(keysStart, rangeIndex, "rangeIndex", rangeCount, "rangeCount");
             CheckDataSize(keyStartLengths, rangeIndex, "rangeIndex", rangeCount, "rangeCount");
@@ -657,7 +657,7 @@ namespace Microsoft.Isam.Esent.Interop.Implementation
         /// <returns>An error if the call fails.</returns>
         public int JetSetCursorFilter(JET_SESID sesid, JET_TABLEID tableid, JET_INDEX_COLUMN[] filters, CursorFilterGrbit grbit)
         {
-            TraceFunctionCall("JetSetCursorFilter");
+            TraceFunctionCall();
             this.CheckSupportsWindows8Features("JetSetCursorFilter");
 
             if (filters == null || filters.Length == 0)

--- a/EsentInterop/jet_err.cs
+++ b/EsentInterop/jet_err.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Isam.Esent.Interop
         LoggingDisabled = -516,
 
         /// <summary>
-        /// Log buffer is too small for recovery
+        /// An operation generated a log record which was too large to fit in the log buffer or in a single log file
         /// </summary>
         LogBufferTooSmall = -517,
 

--- a/EsentInteropSamples/BasicTest/BasicTest.csproj
+++ b/EsentInteropSamples/BasicTest/BasicTest.csproj
@@ -1,16 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{08819B49-02B8-4F93-A143-F9B0461CEA64}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BasicTest</RootNamespace>
     <AssemblyName>BasicTest</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -18,6 +18,7 @@
     <UpgradeBackupLocation />
     <TargetFrameworkProfile />
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -29,6 +30,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -39,20 +41,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
+  
   <ItemGroup>
     <Compile Include="Basic.cs" />
     <Compile Include="DataGenerator.cs" />
@@ -61,16 +50,18 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TempTableTests.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\EsentInterop\EsentInterop.csproj">
       <Project>{E929E163-52A0-4AAC-917B-6D7FAF70C45E}</Project>
       <Name>EsentInterop</Name>
     </ProjectReference>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="app.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EsentInteropSamples/DbUtil/DbUtil.csproj
+++ b/EsentInteropSamples/DbUtil/DbUtil.csproj
@@ -1,16 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{E0B163B0-5AC6-4304-B932-BFC1F6A2A4EB}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DbUtil</RootNamespace>
     <AssemblyName>DbUtil</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -18,6 +18,7 @@
     <UpgradeBackupLocation />
     <TargetFrameworkProfile />
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -29,6 +30,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -39,12 +41,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
+  
   <ItemGroup>
     <Compile Include="CreateSampleDb.cs" />
     <Compile Include="DumpMetaData.cs" />
@@ -53,16 +50,18 @@
     <Compile Include="Dbutil.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\EsentInterop\EsentInterop.csproj">
       <Project>{E929E163-52A0-4AAC-917B-6D7FAF70C45E}</Project>
       <Name>EsentInterop</Name>
     </ProjectReference>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="app.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EsentInteropSamples/DbUtilTests/DbUtilTests.csproj
+++ b/EsentInteropSamples/DbUtilTests/DbUtilTests.csproj
@@ -1,16 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{C9B82A4F-8306-41A9-91DA-1BA5080F1DB0}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DbUtilTests</RootNamespace>
     <AssemblyName>DbUtilTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <FileUpgradeFlags>
@@ -19,6 +19,7 @@
     <UpgradeBackupLocation />
     <TargetFrameworkProfile />
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -30,6 +31,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -40,22 +42,26 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DbutilTests.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\DbUtil\DbUtil.csproj">
       <Project>{E0B163B0-5AC6-4304-B932-BFC1F6A2A4EB}</Project>
       <Name>DbUtil</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EsentInteropSamples/EsentSample/EsentSample.csproj
+++ b/EsentInteropSamples/EsentSample/EsentSample.csproj
@@ -1,16 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{44D46916-891F-435F-B914-AE8AC80613FD}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EsentSample</RootNamespace>
     <AssemblyName>EsentSample</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -18,6 +18,7 @@
     <UpgradeBackupLocation />
     <TargetFrameworkProfile />
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -32,6 +33,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -42,23 +44,23 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="EsentSample.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\EsentInterop\EsentInterop.csproj">
       <Project>{E929E163-52A0-4AAC-917B-6D7FAF70C45E}</Project>
       <Name>EsentInterop</Name>
     </ProjectReference>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="app.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EsentInteropSamples/StockSample/StockSample.csproj
+++ b/EsentInteropSamples/StockSample/StockSample.csproj
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>StockSample</RootNamespace>
     <AssemblyName>StockSample</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -18,6 +20,7 @@
     <UpgradeBackupLocation />
     <TargetFrameworkProfile />
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -30,6 +33,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -41,23 +45,23 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-  </ItemGroup>
+  
   <ItemGroup>
     <Compile Include="StockSample.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\EsentInterop\EsentInterop.csproj">
       <Project>{E929E163-52A0-4AAC-917B-6D7FAF70C45E}</Project>
       <Name>EsentInterop</Name>
     </ProjectReference>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="app.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EsentInteropTests/BasicTableTests.cs
+++ b/EsentInteropTests/BasicTableTests.cs
@@ -1096,7 +1096,11 @@ namespace InteropApiTests
             }
             catch (EsentDatabaseFileReadOnlyException)
             {
-                // Expected.
+                // Expected on Windows 10 20H1 and beyond.
+            }
+            catch (EsentPermissionDeniedException)
+            {
+                // Expected on Windows 10 19H2 and below.
             }
             finally
             {

--- a/EsentInteropTests/EsentInteropTests.csproj
+++ b/EsentInteropTests/EsentInteropTests.csproj
@@ -1,17 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <DefineConstants>$(DefineConstants);MANAGEDESENT_SUPPORTS_ANSI</DefineConstants>
-    <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{85B2B7BB-BF95-42DF-8CBF-348AEF63BD1F}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>InteropApiTests</RootNamespace>
     <AssemblyName>InteropApiTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <DefineConstants>$(DefineConstants);MANAGEDESENT_EXTERNAL_RELEASE</DefineConstants>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SignAssembly>true</SignAssembly>
@@ -22,12 +24,14 @@
     <UpgradeBackupLocation />
     <TargetFrameworkProfile />
   </PropertyGroup>
+
   <!-- The .snk file won't be published to codeplex. -->
   <PropertyGroup Condition="Exists('$(PublicKeyFile)')">
     <DefineConstants>$(DefineConstants);STRONG_NAMED</DefineConstants>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>$(PublicKeyFile)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -42,6 +46,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -53,30 +58,27 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="Rhino.Mocks, Version=3.5.0.1337, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\External Components\Rhino.Mocks\Rhino.Mocks.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="*.cs" Exclude="Vstestdescriptors.cs" />
     <Compile Include="IsamTests\*.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\EsentInteropSamples\DbUtil\DbUtil.csproj">
       <Project>{E0B163B0-5AC6-4304-B932-BFC1F6A2A4EB}</Project>
@@ -91,7 +93,7 @@
       <Name>EsentInterop</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/EsentInteropTests/PrereadRangesTests.cs
+++ b/EsentInteropTests/PrereadRangesTests.cs
@@ -157,7 +157,7 @@ namespace InteropApiTests
             this.CreateAndPopulateTable();
             Api.JetCloseDatabase(this.sesId, this.dbId, CloseDatabaseGrbit.None);
             Api.JetDetachDatabase(this.sesId, this.database);
-            Api.JetAttachDatabase(this.sesId, this.database, Windows8Grbits.PurgeCacheOnAttach);
+            this.AttachDatabase(this.sesId, this.database, Windows8Grbits.PurgeCacheOnAttach);
             Api.JetOpenDatabase(this.sesId, this.database, null, out this.dbId, OpenDatabaseGrbit.None);
             Api.JetOpenTable(this.sesId, this.dbId, this.tableName, null, 0, OpenTableGrbit.None, out this.tableId);
 
@@ -1919,6 +1919,21 @@ namespace InteropApiTests
         #region Helpers
 
         /// <summary>
+        /// Attaches a database
+        /// </summary>
+        /// <param name="session">The session.</param>
+        /// <param name="databasePath">The database path.</param>
+        /// <param name="grbit">The grbit.</param>
+        private void AttachDatabase(JET_SESID session, string databasePath, AttachDatabaseGrbit grbit)
+        {
+#if MANAGEDESENT_ON_WSA
+            Api.JetAttachDatabase(session, databasePath, grbit);
+#else
+            this.AttachDatabaseInternal(session, databasePath, grbit);
+#endif
+        }
+
+        /// <summary>
         /// Create table with 4 records per page
         /// </summary>
         private void CreateAndPopulateTable()
@@ -2307,7 +2322,7 @@ namespace InteropApiTests
             Api.JetCloseTable(this.sesId, this.tableId);
             Api.JetCloseDatabase(this.sesId, this.dbId, CloseDatabaseGrbit.None);
             Api.JetDetachDatabase(this.sesId, this.database);
-            Api.JetAttachDatabase(this.sesId, this.database, Windows8Grbits.PurgeCacheOnAttach);
+            this.AttachDatabase(this.sesId, this.database, Windows8Grbits.PurgeCacheOnAttach);
             Api.JetOpenDatabase(this.sesId, this.database, null, out this.dbId, OpenDatabaseGrbit.None);
             Api.JetOpenTable(this.sesId, this.dbId, this.tableName, null, 0, OpenTableGrbit.None, out this.tableId);
 

--- a/EsentInteropTests/PrereadRangesTests.cs
+++ b/EsentInteropTests/PrereadRangesTests.cs
@@ -1926,7 +1926,7 @@ namespace InteropApiTests
         /// <param name="grbit">The grbit.</param>
         private void AttachDatabase(JET_SESID session, string databasePath, AttachDatabaseGrbit grbit)
         {
-#if MANAGEDESENT_ON_WSA
+#if MANAGEDESENT_ON_WSA || MANAGEDESENT_EXTERNAL_RELEASE
             Api.JetAttachDatabase(session, databasePath, grbit);
 #else
             this.AttachDatabaseInternal(session, databasePath, grbit);

--- a/EsentInteropTests/PrereadRangesTests.cs
+++ b/EsentInteropTests/PrereadRangesTests.cs
@@ -157,7 +157,7 @@ namespace InteropApiTests
             this.CreateAndPopulateTable();
             Api.JetCloseDatabase(this.sesId, this.dbId, CloseDatabaseGrbit.None);
             Api.JetDetachDatabase(this.sesId, this.database);
-            this.AttachDatabase(this.sesId, this.database, Windows8Grbits.PurgeCacheOnAttach);
+            Api.JetAttachDatabase(this.sesId, this.database, Windows8Grbits.PurgeCacheOnAttach);
             Api.JetOpenDatabase(this.sesId, this.database, null, out this.dbId, OpenDatabaseGrbit.None);
             Api.JetOpenTable(this.sesId, this.dbId, this.tableName, null, 0, OpenTableGrbit.None, out this.tableId);
 
@@ -1919,21 +1919,6 @@ namespace InteropApiTests
         #region Helpers
 
         /// <summary>
-        /// Attaches a database
-        /// </summary>
-        /// <param name="session">The session.</param>
-        /// <param name="databasePath">The database path.</param>
-        /// <param name="grbit">The grbit.</param>
-        private void AttachDatabase(JET_SESID session, string databasePath, AttachDatabaseGrbit grbit)
-        {
-#if MANAGEDESENT_ON_WSA
-            Api.JetAttachDatabase(session, databasePath, grbit);
-#else
-            this.AttachDatabaseInternal(session, databasePath, grbit);
-#endif
-        }
-
-        /// <summary>
         /// Create table with 4 records per page
         /// </summary>
         private void CreateAndPopulateTable()
@@ -2322,7 +2307,7 @@ namespace InteropApiTests
             Api.JetCloseTable(this.sesId, this.tableId);
             Api.JetCloseDatabase(this.sesId, this.dbId, CloseDatabaseGrbit.None);
             Api.JetDetachDatabase(this.sesId, this.database);
-            this.AttachDatabase(this.sesId, this.database, Windows8Grbits.PurgeCacheOnAttach);
+            Api.JetAttachDatabase(this.sesId, this.database, Windows8Grbits.PurgeCacheOnAttach);
             Api.JetOpenDatabase(this.sesId, this.database, null, out this.dbId, OpenDatabaseGrbit.None);
             Api.JetOpenTable(this.sesId, this.dbId, this.tableName, null, 0, OpenTableGrbit.None, out this.tableId);
 

--- a/EsentInteropTests/ese/UnpublishedBasicTableTests.cs
+++ b/EsentInteropTests/ese/UnpublishedBasicTableTests.cs
@@ -1,0 +1,47 @@
+//-----------------------------------------------------------------------
+// <copyright file="UnpublishedBasicTableTests.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace InteropApiTests
+{
+    using Microsoft.Isam.Esent.Interop;
+    using Microsoft.Isam.Esent.Interop.Unpublished;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Unpublished Basic Api tests
+    /// </summary>
+    public partial class BasicTableTests
+    {
+        #region JetDefragment Tests
+
+        /// <summary>
+        /// Test starting OLD2 with DefragmentBTreeBatch on read-only database.
+        /// </summary>
+        [TestMethod]
+        [Priority(2)]
+        [Description("Start OLD2 with DefragmentBTreeBatch on read-only database must fail")]
+        public void TestStartOld2WithDefragmentBTreeBatchReadOnlyDbMustFail()
+        {
+            this.ReattachDatabase(AttachDatabaseGrbit.ReadOnly);
+            try
+            {
+                DefragGrbit defragGrbit = UnpublishedGrbits.DefragmentBTreeBatch | DefragGrbit.BatchStart;
+                Api.Defragment(this.sesid, this.dbid, null, defragGrbit);
+                Assert.Fail("Starting OLD2 with {0} should have failed with EsentDatabaseFileReadOnlyException, but succeeded.", defragGrbit);
+            }
+            catch (EsentDatabaseFileReadOnlyException)
+            {
+                // Expected.
+            }
+            finally
+            {
+                this.ReattachDatabase(AttachDatabaseGrbit.None);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/isam/isam.csproj
+++ b/isam/isam.csproj
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EsentIsam</RootNamespace>
     <AssemblyName>Esent.Isam</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <PublicKeyFile>..\scripts\internal\35MSSharedLib1024.snk</PublicKeyFile>
@@ -35,12 +37,14 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
   </PropertyGroup>
+
   <!-- The .snk file won't be published to codeplex. -->
   <PropertyGroup Condition="Exists('$(PublicKeyFile)')">
     <DefineConstants>$(DefineConstants);STRONG_NAMED</DefineConstants>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>$(PublicKeyFile)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -53,6 +57,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -64,26 +69,20 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="*.cs" Exclude="assemblyinfo.cs" />
     <Compile Include="properties\assemblyinfo.cs" />
     <Compile Include="config\*.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\EsentInterop\EsentInterop.csproj">
       <Project>{E929E163-52A0-4AAC-917B-6D7FAF70C45E}</Project>
       <Name>EsentInterop</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/isamunittests/isamunittests.csproj
+++ b/isamunittests/isamunittests.csproj
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,7 +11,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IsamUnitTests</RootNamespace>
     <AssemblyName>IsamUnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SignAssembly>true</SignAssembly>
@@ -22,12 +24,14 @@
     <UpgradeBackupLocation />
     <TargetFrameworkProfile />
   </PropertyGroup>
+
   <!-- The .snk file won't be published to codeplex. -->
   <PropertyGroup Condition="Exists('$(PublicKeyFile)')">
     <DefineConstants>$(DefineConstants);STRONG_NAMED</DefineConstants>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>$(PublicKeyFile)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -42,6 +46,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -53,29 +58,26 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="Rhino.Mocks, Version=3.5.0.1337, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\External Components\Rhino.Mocks\Rhino.Mocks.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="*.cs" Exclude="AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\EsentInterop\EsentInterop.csproj">
       <Project>{E929E163-52A0-4AAC-917B-6D7FAF70C45E}</Project>
@@ -89,7 +91,7 @@
       <Name>EsentInteropTests</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Pull changes from Microsoft's internal release of ManagedEsent code.

Main change is that all built-in support for binary serialization is being removed from ManagedEsent and EsentCollections. Any products needing support for serialization will need to remain on the previous version for now, though it is recommended to move away from binary serialization if possible.