### PR TITLE
Add support for a custom ColumnConverter

### DIFF
--- a/EsentCollections/ColumnConverter.cs
+++ b/EsentCollections/ColumnConverter.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
     /// database.
     /// </summary>
     /// <typeparam name="TColumn">The type of the column.</typeparam>
-    internal class ColumnConverter<TColumn>
+    internal class ColumnConverter<TColumn> : IColumnConverter<TColumn>
     {
         /// <summary>
         /// A mapping of types to RetrieveColumn function names.
@@ -97,12 +97,12 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// <summary>
         /// The SetColumn delegate for this object.
         /// </summary>
-        private readonly SetColumnDelegate columnSetter;
+        private readonly SetColumnDelegate<TColumn> columnSetter;
 
         /// <summary>
         /// The RetrieveColumn delegate for this object.
         /// </summary>
-        private readonly RetrieveColumnDelegate columnRetriever;
+        private readonly RetrieveColumnDelegate<TColumn> columnRetriever;
 
         /// <summary>
         /// The column type for this object.
@@ -141,25 +141,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
             RuntimeHelpers.PrepareDelegate(this.columnSetter);
             RuntimeHelpers.PrepareDelegate(this.columnRetriever);
         }
-
-        /// <summary>
-        /// Represents a SetColumn operation.
-        /// </summary>
-        /// <param name="sesid">The session to use.</param>
-        /// <param name="tableid">The cursor to set the value in. An update should be prepared.</param>
-        /// <param name="columnid">The column to set.</param>
-        /// <param name="value">The value to set.</param>
-        public delegate void SetColumnDelegate(JET_SESID sesid, JET_TABLEID tableid, JET_COLUMNID columnid, TColumn value);
-
-        /// <summary>
-        /// Represents a RetrieveColumn operation.
-        /// </summary>
-        /// <param name="sesid">The session to use.</param>
-        /// <param name="tableid">The cursor to retrieve the value from.</param>
-        /// <param name="columnid">The column to retrieve.</param>
-        /// <returns>The retrieved value.</returns>
-        public delegate TColumn RetrieveColumnDelegate(JET_SESID sesid, JET_TABLEID tableid, JET_COLUMNID columnid);
-
+        
         /// <summary>
         /// Gets the type of database column the value should be stored in.
         /// </summary>
@@ -175,7 +157,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// Gets a delegate that can be used to set the Key column with an object of
         /// type <see cref="Type"/>.
         /// </summary>
-        public SetColumnDelegate ColumnSetter
+        public SetColumnDelegate<TColumn> ColumnSetter
         {
             get
             {
@@ -187,7 +169,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// Gets a delegate that can be used to retrieve the Key column, returning
         /// type <see cref="Type"/>.
         /// </summary>
-        public RetrieveColumnDelegate ColumnRetriever
+        public RetrieveColumnDelegate<TColumn> ColumnRetriever
         {
             get
             {
@@ -787,7 +769,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// Get the retrieve column delegate for the type.
         /// </summary>
         /// <returns>The retrieve column delegate for the type.</returns>
-        private static RetrieveColumnDelegate CreateRetrieveColumnDelegate()
+        private static RetrieveColumnDelegate<TColumn> CreateRetrieveColumnDelegate()
         {
             // Look for a method called "RetrieveColumnAs{Type}", which will return a
             // nullable version of the type (except for strings, which are are ready 
@@ -813,7 +795,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
                                                                null);
 
                 // Return the string/nullable type.
-                return (RetrieveColumnDelegate)Delegate.CreateDelegate(typeof(RetrieveColumnDelegate), retrieveColumnMethod);
+                return (RetrieveColumnDelegate<TColumn>)Delegate.CreateDelegate(typeof(RetrieveColumnDelegate<TColumn>), retrieveColumnMethod);
             }
             else
             {
@@ -829,7 +811,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
                                                                retrieveColumnArguments,
                                                                null);
 
-                return (RetrieveColumnDelegate)Delegate.CreateDelegate(typeof(RetrieveColumnDelegate), retrieveNonNullableColumnMethod);
+                return (RetrieveColumnDelegate<TColumn>)Delegate.CreateDelegate(typeof(RetrieveColumnDelegate<TColumn>), retrieveNonNullableColumnMethod);
             }
         }
 
@@ -837,7 +819,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// Create the set column delegate.
         /// </summary>
         /// <returns>The set column delegate.</returns>
-        private static SetColumnDelegate CreateSetColumnDelegate()
+        private static SetColumnDelegate<TColumn> CreateSetColumnDelegate()
         {
             // Look for a method called "SetColumn", which takes a TColumn.
             // First look for a private method in this class that takes the
@@ -855,7 +837,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
                                                           null,
                                                           setColumnArguments,
                                                           null);
-            return (SetColumnDelegate)Delegate.CreateDelegate(typeof(SetColumnDelegate), setColumnMethod);
+            return (SetColumnDelegate<TColumn>)Delegate.CreateDelegate(typeof(SetColumnDelegate<TColumn>), setColumnMethod);
         }
     }
 }

--- a/EsentCollections/IColumnConverter.cs
+++ b/EsentCollections/IColumnConverter.cs
@@ -1,0 +1,52 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IColumnConverter.cs" company="Microsoft Corporation">
+//   Copyright (c) Microsoft Corporation.
+// </copyright>
+// <summary>
+//   Contains methods to set and get data from the ESENT database.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Isam.Esent.Collections.Generic
+{
+    using Microsoft.Isam.Esent.Interop;
+    
+    /// <summary>
+    /// Represents a SetColumn operation.
+    /// </summary>
+    /// <param name="sesid">The session to use.</param>
+    /// <param name="tableid">The cursor to set the value in. An update should be prepared.</param>
+    /// <param name="columnid">The column to set.</param>
+    /// <param name="value">The value to set.</param>
+    public delegate void SetColumnDelegate<TColumn>(JET_SESID sesid, JET_TABLEID tableid, JET_COLUMNID columnid, TColumn value);
+
+    /// <summary>
+    /// Represents a RetrieveColumn operation.
+    /// </summary>
+    /// <param name="sesid">The session to use.</param>
+    /// <param name="tableid">The cursor to retrieve the value from.</param>
+    /// <param name="columnid">The column to retrieve.</param>
+    /// <returns>The retrieved value.</returns>
+    public delegate TColumn RetrieveColumnDelegate<TColumn>(JET_SESID sesid, JET_TABLEID tableid, JET_COLUMNID columnid);
+    
+    /// <summary>
+    /// Contains methods to set and get data from the ESENT database.
+    /// </summary>
+    public interface IColumnConverter<TColumn>
+    {
+        /// <summary>
+        /// Gets a delegate that can be used to set the Key column with an object of
+        /// </summary>
+        SetColumnDelegate<TColumn> ColumnSetter { get; }
+
+        /// <summary>
+        /// Gets a delegate that can be used to retrieve the Key column, returning
+        /// </summary>
+        RetrieveColumnDelegate<TColumn> ColumnRetriever { get; }
+
+        /// <summary>
+        /// Gets the type of database column the value should be stored in.
+        /// </summary>
+        JET_coltyp Coltyp { get; }
+    }
+}

--- a/EsentCollections/PersistentDictionary.cs
+++ b/EsentCollections/PersistentDictionary.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// <param name="directory">
         /// The directory in which to create the database.
         /// </param>
-        public PersistentDictionary(string directory) : this(directory, null, null)
+        public PersistentDictionary(string directory) : this(directory, null, null, null)
         {
             if (null == directory)
             {
@@ -127,7 +127,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// Initializes a new instance of the PersistentDictionary class.
         /// </summary>
         /// <param name="customConfig">The custom config to use for creating the PersistentDictionary.</param>
-        public PersistentDictionary(IConfigSet customConfig) : this(null, customConfig, null)
+        public PersistentDictionary(IConfigSet customConfig) : this(null, customConfig, null, null)
         {
             if (null == customConfig)
             {
@@ -140,7 +140,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// </summary>
         /// <param name="directory">The directory in which to create the database.</param>
         /// <param name="customConfig">The custom config to use for creating the PersistentDictionary.</param>
-        public PersistentDictionary(string directory, IConfigSet customConfig) : this(directory, customConfig, null)
+        public PersistentDictionary(string directory, IConfigSet customConfig) : this(directory, customConfig, null, null)
         {
             if (directory == null && customConfig == null)
             {

--- a/EsentCollections/PersistentDictionaryConverters.cs
+++ b/EsentCollections/PersistentDictionaryConverters.cs
@@ -9,6 +9,8 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.Isam.Esent.Collections.Generic
 {
     using Microsoft.Isam.Esent.Interop;
@@ -29,7 +31,20 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// <summary>
         /// Column converter for the value column.
         /// </summary>
-        private readonly ColumnConverter<TValue> valueColumnConverter = new ColumnConverter<TValue>();
+        private readonly IColumnConverter<TValue> valueColumnConverter;
+
+        public PersistentDictionaryConverters() : this(new ColumnConverter<TValue>())
+        {
+        }
+        
+        public PersistentDictionaryConverters(IColumnConverter<TValue> valueColumnConverter)
+        {
+            if (valueColumnConverter == null)
+            {
+                throw new ArgumentNullException("valueColumnConverter");
+            }
+            this.valueColumnConverter = valueColumnConverter;
+        }
 
         /// <summary>
         /// Gets a delegate that can be used to call JetMakeKey with an object of
@@ -47,7 +62,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// Gets a delegate that can be used to set the Key column with an object of
         /// type <typeparamref name="TKey"/>.
         /// </summary>
-        public ColumnConverter<TKey>.SetColumnDelegate SetKeyColumn
+        public SetColumnDelegate<TKey> SetKeyColumn
         {
             get
             {
@@ -59,7 +74,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// Gets a delegate that can be used to set the Value column with an object of
         /// type <typeparamref name="TValue"/>.
         /// </summary>
-        public ColumnConverter<TValue>.SetColumnDelegate SetValueColumn
+        public SetColumnDelegate<TValue> SetValueColumn
         {
             get
             {
@@ -71,7 +86,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// Gets a delegate that can be used to retrieve the Key column, returning
         /// an object of type <typeparamref name="TKey"/>.
         /// </summary>
-        public ColumnConverter<TKey>.RetrieveColumnDelegate RetrieveKeyColumn
+        public RetrieveColumnDelegate<TKey> RetrieveKeyColumn
         {
             get
             {
@@ -83,7 +98,7 @@ namespace Microsoft.Isam.Esent.Collections.Generic
         /// Gets a delegate that can be used to retrieve the Value column, returning
         /// an object of type <typeparamref name="TValue"/>.
         /// </summary>
-        public ColumnConverter<TValue>.RetrieveColumnDelegate RetrieveValueColumn
+        public RetrieveColumnDelegate<TValue> RetrieveValueColumn
         {
             get
             {

--- a/EsentCollectionsTests/CustomColumnConverterTests.cs
+++ b/EsentCollectionsTests/CustomColumnConverterTests.cs
@@ -1,0 +1,464 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CustomColumnConverterTest.cs" company="Microsoft Corporation">
+//   Copyright (c) Microsoft Corporation.
+// </copyright>
+// <summary>
+//   Tests for custom CustomColumnConverter.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace EsentCollectionsTests
+{
+    using System;
+    using System.Globalization;
+    using Microsoft.Database.Isam.Config;
+    using Microsoft.Isam.Esent.Collections.Generic;
+    using Microsoft.Isam.Esent.Interop;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// TODO do we need implement IEquatable<PooledPersistentBlob>?
+    /// <summary>
+    /// An item for storing in PersistentDictionary for these tests.
+    /// </summary>
+    internal class PooledPersistentBlob 
+    {
+        public static readonly TestArrayPool ArrayPool = new TestArrayPool();
+
+        /// <summary>
+        /// Byte array containing the Blob.
+        /// </summary>
+        private readonly byte[] blobData;
+
+        /// <summary>
+        /// Length of the Blob.
+        /// </summary>
+        private readonly int length;
+        
+        /// <summary>Hash code to detect illegal changes to the Blob.</summary>
+        private readonly int blobHashCode;
+
+        public PooledPersistentBlob(byte[] blobData, int length)
+        {
+            if (blobData != null && blobData.Length < length)
+            {
+                throw new ArgumentException(string.Format("length cannot be more, than the array length: blobData.length={0}, length={1}", blobData.Length, length));
+            }
+            
+            this.blobData = blobData;
+            this.length = length;
+            
+            if (blobData == null)
+            {
+                return;
+            }
+            this.blobHashCode = blobData.GetHashCode();
+        }
+        
+        /// <summary>
+        /// Returns the byte array representing the blob.
+        /// </summary>
+        /// <returns>The byte[] array.</returns>
+        public byte[] GetBytes()
+        {
+            return this.blobData;
+        }
+
+        /// <summary>
+        /// Return the length of the blob.
+        /// </summary>
+        /// <returns>The length of the blob.</returns>
+        public int GetLength()
+        {
+            return this.length;
+        }
+
+        /// <summary>
+        /// Get a copy of bytes of the blob.
+        /// </summary>
+        /// <returns>Cope of bytes of the blob.</returns>
+        public byte[] ToArray()
+        {
+            if (this.blobData == null || this.blobData.Length == 0 || this.length == 0)
+            {
+                return new byte[] { };
+            }
+
+            byte[] result = new byte[this.length];
+            Array.Copy(this.blobData, result, this.length);
+            return result;
+        }
+        
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A Int32 that contains the hash code for this instance.</returns>
+        public override int GetHashCode()
+        {
+            return this.blobData.GetHashCode();
+        }
+
+        /// <summary>
+        /// Checks that this instance hasn't changed illegally, throws an exception if it did.
+        /// </summary>
+        public void CheckImmutability()
+        {
+            int currentHashCode = this.blobData != null ? this.blobData.GetHashCode() : 0;
+            if (currentHashCode != this.blobHashCode)
+            {
+                throw new InvalidOperationException("A PooledPersistentBlob was changed in memory without being changed in the associated PersistentDictionary.");
+            }
+        }
+    }
+    
+    /// <summary>
+    /// ColumnConverter for PooledPersistentBlob
+    /// </summary>
+    internal class PersistentBlobCustomColumnConverter : IColumnConverter<PooledPersistentBlob>
+    {
+        internal static int setColumnExecutionsCounter = 0;
+        internal static int retrieveColumnExecutionsCounter = 0;
+        internal const int initialAllocaitonSize = 93;
+        
+        public SetColumnDelegate<PooledPersistentBlob> ColumnSetter
+        {
+            get { return SetColumn; }
+        }
+
+        public RetrieveColumnDelegate<PooledPersistentBlob> ColumnRetriever{
+            get { return RetrieveColumn; }
+        }
+
+        public JET_coltyp Coltyp
+        {
+            get { return JET_coltyp.LongBinary; }
+        }
+        
+        private static void SetColumn(JET_SESID sesid, JET_TABLEID tableid, JET_COLUMNID columnid, PooledPersistentBlob value)
+        {
+            value.CheckImmutability();
+            Api.SetColumn(sesid, tableid, columnid, value.GetBytes(), value.GetLength(), SetColumnGrbit.None);
+            setColumnExecutionsCounter++;
+        }
+        
+        private static PooledPersistentBlob RetrieveColumn(JET_SESID sesid, JET_TABLEID tableid, JET_COLUMNID columnid)
+        {
+            retrieveColumnExecutionsCounter++;
+            
+            byte[] data = PooledPersistentBlob.ArrayPool.Rent(initialAllocaitonSize);
+            int dataSize;
+            
+            JET_wrn wrn;
+
+            try
+            {
+                wrn = Api.RetrieveColumn(sesid, tableid, columnid, data, data.Length, out dataSize, RetrieveColumnGrbit.None, null);
+            }
+            catch (Exception ex)
+            {
+                PooledPersistentBlob.ArrayPool.Return(data);
+                throw;
+            }
+
+            if (JET_wrn.ColumnNull == wrn)
+            {
+                // null column
+                PooledPersistentBlob.ArrayPool.Return(data);
+                return new PooledPersistentBlob(null, 0);
+            }
+
+            if (JET_wrn.Success == wrn)
+            {
+                return new PooledPersistentBlob(data, dataSize);
+            }
+
+            // there is more data to retrieve, so we need another buffer
+            PooledPersistentBlob.ArrayPool.Return(data);
+           
+            data = PooledPersistentBlob.ArrayPool.Rent(dataSize);
+            int newDataSize;
+
+            try
+            {
+                wrn = Api.RetrieveColumn(sesid, tableid, columnid, data, data.Length, out newDataSize, RetrieveColumnGrbit.None, null);
+            }
+            catch (Exception ex)
+            {
+                PooledPersistentBlob.ArrayPool.Return(data);
+                throw;
+            }
+
+            if (JET_wrn.BufferTruncated == wrn)
+            {
+                PooledPersistentBlob.ArrayPool.Return(data);
+                string error = string.Format(
+                    CultureInfo.CurrentCulture,
+                    "Column size changed from {0} to {1}. The record was probably updated by another thread.",
+                    data.Length,
+                    newDataSize);
+                throw new InvalidOperationException(error);
+            }
+
+            return new PooledPersistentBlob(data, newDataSize);
+        }
+    }
+    
+    /// <summary>
+    /// Test a class that implements IColumnConverter.
+    /// </summary>
+    [TestClass]
+    public class CustomColumnConverterTests
+    {
+        /// <summary>
+        /// Path to put the dictionary in.
+        /// </summary>
+        private const string DictionaryPath = "CustomColumnConverter";
+        
+        /// <summary>
+        /// The dictionary we are testing.
+        /// </summary>
+        private PersistentDictionary<string, PooledPersistentBlob> dictionary;
+
+        /// <summary>
+        /// Test initialization.
+        /// </summary>
+        [TestInitialize]
+        public void Setup()
+        {
+            this.dictionary = new PersistentDictionary<string, PooledPersistentBlob>(DictionaryPath, new DatabaseConfig()
+            {
+                DisplayName = "CustomColumnConverterTestsDb"
+            }, new PersistentBlobCustomColumnConverter());
+        }
+
+        /// <summary>
+        /// Cleanup after the test.
+        /// </summary>
+        [TestCleanup]
+        public void Teardown()
+        {
+            PooledPersistentBlob.ArrayPool.arrayAllocatedCounter = 0;
+            PooledPersistentBlob.ArrayPool.arrayRentedCounter = 0;
+            PooledPersistentBlob.ArrayPool.arrayReturnedCounter = 0;
+            PooledPersistentBlob.ArrayPool.ClearPool();
+            
+            PersistentBlobCustomColumnConverter.setColumnExecutionsCounter = 0;
+            PersistentBlobCustomColumnConverter.retrieveColumnExecutionsCounter = 0;
+            
+            this.dictionary.Dispose();
+            Cleanup.DeleteDirectoryWithRetry(DictionaryPath);
+        }
+        
+        /// <summary>
+        /// Can add/read an array with custom lenght.
+        /// </summary>
+        [TestMethod]
+        [Priority(2)]
+        public void AddAndReadArrayWithLenghtTest()
+        {
+            byte[] expectedArray = new byte[]{1, 2, 3};
+            string key = "key";
+            this.dictionary[key] = new PooledPersistentBlob(new byte[]{1, 2, 3, 4, 5}, 3);
+            this.dictionary.Flush();
+
+            PooledPersistentBlob actualBlob;
+            Assert.IsTrue(this.dictionary.TryGetValue(key, out actualBlob));
+            
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.setColumnExecutionsCounter, "setColumn should be executed once");
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.retrieveColumnExecutionsCounter, "retrieveColumn should be executed once");
+            CollectionAssert.AreEqual(expectedArray, actualBlob.ToArray());
+            
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayRentedCounter);
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayAllocatedCounter);
+            Assert.AreEqual(0, PooledPersistentBlob.ArrayPool.arrayReturnedCounter);
+            Assert.AreEqual(0, PooledPersistentBlob.ArrayPool.GetNumberOfCurrentArraysInPool());
+        }
+        
+        /// <summary>
+        /// Can add, and twice read an array with custom lenght without additional allocation.
+        /// </summary>
+        [TestMethod]
+        [Priority(2)]
+        public void AddAndReadArrayWithLenghtTwiceTest()
+        {
+            byte[] expectedArray = new byte[]{1, 2, 3};
+            string key = "key";
+            this.dictionary[key] = new PooledPersistentBlob(new byte[]{1, 2, 3, 4, 5}, 3);
+            this.dictionary.Flush();
+
+            PooledPersistentBlob actualBlob;
+            Assert.IsTrue(this.dictionary.TryGetValue(key, out actualBlob));
+            
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.setColumnExecutionsCounter, "setColumn should be executed once");
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.retrieveColumnExecutionsCounter, "retrieveColumn should be executed once");
+            CollectionAssert.AreEqual(expectedArray, actualBlob.ToArray());
+            
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayRentedCounter);
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayAllocatedCounter);
+            Assert.AreEqual(0, PooledPersistentBlob.ArrayPool.arrayReturnedCounter);
+            
+            // return array to pool
+            PooledPersistentBlob.ArrayPool.Return(actualBlob.GetBytes());
+            CollectionAssert.AreNotEqual(expectedArray, actualBlob.ToArray());
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.GetNumberOfCurrentArraysInPool());
+            
+            // read the second time
+            Assert.IsTrue(this.dictionary.TryGetValue(key, out actualBlob));
+            
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.setColumnExecutionsCounter, "setColumn should be executed once");
+            Assert.AreEqual(2, PersistentBlobCustomColumnConverter.retrieveColumnExecutionsCounter, "retrieveColumn should be executed once");
+            CollectionAssert.AreEqual(expectedArray, actualBlob.ToArray());
+            
+            Assert.AreEqual(2, PooledPersistentBlob.ArrayPool.arrayRentedCounter);
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayAllocatedCounter);
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayReturnedCounter);
+            Assert.AreEqual(0, PooledPersistentBlob.ArrayPool.GetNumberOfCurrentArraysInPool());
+        }
+        
+        /// <summary>
+        /// Can add/read an array with full lenght.
+        /// </summary>
+        [TestMethod]
+        [Priority(2)]
+        public void AddAndReadArrayWithFullLenghtTest()
+        {
+            byte[] expectedArray = new byte[]{1, 2, 3, 4, 5};
+            byte[] storedArray = new byte[]{1, 2, 3, 4, 5};
+            string key = "key";
+            this.dictionary[key] = new PooledPersistentBlob(storedArray, storedArray.Length);
+            this.dictionary.Flush();
+
+            PooledPersistentBlob actualBlob;
+            Assert.IsTrue(this.dictionary.TryGetValue(key, out actualBlob));
+            
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.setColumnExecutionsCounter, "setColumn should be executed once");
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.retrieveColumnExecutionsCounter, "retrieveColumn should be executed once");
+            CollectionAssert.AreEqual(expectedArray, actualBlob.ToArray());
+            
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayRentedCounter);
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayAllocatedCounter);
+            Assert.AreEqual(0, PooledPersistentBlob.ArrayPool.arrayReturnedCounter);
+            Assert.AreEqual(0, PooledPersistentBlob.ArrayPool.GetNumberOfCurrentArraysInPool());
+        }
+        
+        /// <summary>
+        /// Can add/read a big array in LOH (>85kb) with custom lenght.
+        /// </summary>
+        [TestMethod]
+        [Priority(2)]
+        public void AddAndReadArrayInLargeHeapWithLenghtTest()
+        {
+            const int lenght = 100_000;
+            byte[] expectedArray = new byte[lenght];
+            byte[] storedArray = new byte[2 * lenght];
+
+            for (int i = 0; i < lenght * 2; i++)
+            {
+                if (i < lenght)
+                {
+                    expectedArray[i] = (byte) (i % 256);
+                }
+                storedArray[i] = (byte) (i % 256);
+            }
+            
+            string key = "key";
+            this.dictionary[key] = new PooledPersistentBlob(storedArray, lenght);
+            this.dictionary.Flush();
+
+            PooledPersistentBlob actualBlob;
+            Assert.IsTrue(this.dictionary.TryGetValue(key, out actualBlob));
+            
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.setColumnExecutionsCounter, "setColumn should be executed once");
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.retrieveColumnExecutionsCounter, "retrieveColumn should be executed once");
+            CollectionAssert.AreEqual(expectedArray, actualBlob.ToArray());
+            
+            Assert.AreEqual(2, PooledPersistentBlob.ArrayPool.arrayRentedCounter);
+            Assert.AreEqual(2, PooledPersistentBlob.ArrayPool.arrayAllocatedCounter);
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayReturnedCounter);
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.GetNumberOfCurrentArraysInPool());
+        }
+        
+        /// <summary>
+        /// Can add/read a big array in LOH (>85kb) with full lenght.
+        /// </summary>
+        [TestMethod]
+        [Priority(2)]
+        public void AddAndReadArrayInLargeHeapWithFullLenghtTest()
+        {
+            const int lenght = 100_000;
+            byte[] expectedArray = new byte[lenght];
+            byte[] storedArray = new byte[lenght];
+
+            for (int i = 0; i < lenght; i++)
+            {
+                expectedArray[i] = (byte) (i % 256);
+                storedArray[i] = (byte) (i % 256);
+            }
+            
+            string key = "key";
+            this.dictionary[key] = new PooledPersistentBlob(storedArray, storedArray.Length);
+            this.dictionary.Flush();
+
+            PooledPersistentBlob actualBlob;
+            Assert.IsTrue(this.dictionary.TryGetValue(key, out actualBlob));
+            
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.setColumnExecutionsCounter, "setColumn should be executed once");
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.retrieveColumnExecutionsCounter, "retrieveColumn should be executed once");
+            CollectionAssert.AreEqual(expectedArray, actualBlob.ToArray());
+            
+            Assert.AreEqual(2, PooledPersistentBlob.ArrayPool.arrayRentedCounter);
+            Assert.AreEqual(2, PooledPersistentBlob.ArrayPool.arrayAllocatedCounter);
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayReturnedCounter);
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.GetNumberOfCurrentArraysInPool());
+        }
+        
+        /// <summary>
+        /// Can add/read an empty array.
+        /// </summary>
+        [TestMethod]
+        [Priority(2)]
+        public void AddAndReadEmptyArrayWithLenghtTest()
+        {
+            byte[] expectedArray = new byte[]{};
+            string key = "key";
+            this.dictionary[key] = new PooledPersistentBlob(new byte[]{}, 0);
+            this.dictionary.Flush();
+
+            PooledPersistentBlob actualBlob;
+            Assert.IsTrue(this.dictionary.TryGetValue(key, out actualBlob));
+            
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.setColumnExecutionsCounter, "setColumn should be executed once");
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.retrieveColumnExecutionsCounter, "retrieveColumn should be executed once");
+            CollectionAssert.AreEqual(expectedArray, actualBlob.ToArray());
+            
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayRentedCounter);
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayAllocatedCounter);
+            Assert.AreEqual(0, PooledPersistentBlob.ArrayPool.arrayReturnedCounter);
+            Assert.AreEqual(0, PooledPersistentBlob.ArrayPool.GetNumberOfCurrentArraysInPool());
+        }
+        
+        /// <summary>
+        /// Can add/read an null array.
+        /// </summary>
+        [TestMethod]
+        [Priority(2)]
+        public void AddAndReadNullArrayWithLenghtTest()
+        {
+            byte[] expectedArray = new byte[]{};
+            string key = "key";
+            this.dictionary[key] = new PooledPersistentBlob(null, 0);
+            this.dictionary.Flush();
+
+            PooledPersistentBlob actualBlob;
+            Assert.IsTrue(this.dictionary.TryGetValue(key, out actualBlob));
+            
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.setColumnExecutionsCounter, "setColumn should be executed once");
+            Assert.AreEqual(1, PersistentBlobCustomColumnConverter.retrieveColumnExecutionsCounter, "retrieveColumn should be executed once");
+            CollectionAssert.AreEqual(expectedArray, actualBlob.ToArray());
+            
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayRentedCounter);
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayAllocatedCounter);
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayReturnedCounter);
+            Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.GetNumberOfCurrentArraysInPool());
+        }
+    }
+}

--- a/EsentCollectionsTests/CustomColumnConverterTests.cs
+++ b/EsentCollectionsTests/CustomColumnConverterTests.cs
@@ -460,5 +460,32 @@ namespace EsentCollectionsTests
             Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.arrayReturnedCounter);
             Assert.AreEqual(1, PooledPersistentBlob.ArrayPool.GetNumberOfCurrentArraysInPool());
         }
+        
+        /// <summary>
+        /// Cannot add an element, when data is null, but lenght is more than 0.
+        /// </summary>
+        [TestMethod]
+        [Priority(2)]
+        [ExpectedException(typeof(ArgumentException))]
+        public void AddWhenDataIsNullAndLenghtIsNot0Test()
+        {
+            string key = "key";
+            this.dictionary[key] = new PooledPersistentBlob(null, 1);
+            this.dictionary.Flush();
+        }
+        
+        /// <summary>
+        /// Cannot add an element, when data lenght is less than dataSize.
+        /// </summary>
+        [TestMethod]
+        [Priority(2)]
+        [ExpectedException(typeof(ArgumentException))]
+        public void AddWhenDataLenghtIsLessThanDataSizeTest()
+        {
+            string key = "key";
+            byte[] data = new byte[]{1, 2, 3, 4, 5};
+            this.dictionary[key] = new PooledPersistentBlob(data, data.Length + 1);
+            this.dictionary.Flush();
+        }
     }
 }

--- a/EsentCollectionsTests/TestArrayPool.cs
+++ b/EsentCollectionsTests/TestArrayPool.cs
@@ -1,0 +1,92 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="file="TestArrayPool.cs"" company="Microsoft Corporation">
+//   Copyright (c) Microsoft Corporation.
+// </copyright>
+// <summary>
+//   Implementation of a simple ArrayPool for tests, where it is needed to have such class. 
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace EsentCollectionsTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    
+    internal class TestArrayPool
+    {
+        private readonly Dictionary<int, List<byte[]>> buffers = new Dictionary<int, List<byte[]>>();
+        internal int arrayAllocatedCounter = 0;
+        internal int arrayRentedCounter = 0;
+        internal int arrayReturnedCounter = 0;
+        
+        /// <summary>
+        /// Rent an array from the pool
+        /// </summary>
+        internal byte[] Rent(int minimumLength)
+        {
+            if (minimumLength == 0)
+            {
+                return new byte[] { };
+            }
+
+            arrayRentedCounter++;
+            int power = CalculateBucketIndex(minimumLength);
+            int arraySize = (int) Math.Pow(2, power);
+
+            if (buffers.ContainsKey(power))
+            {
+                List<byte[]> bytesList = buffers[power];
+                if (bytesList.Count > 0)
+                {
+                    byte[] result = bytesList[bytesList.Count - 1];
+                    bytesList.RemoveAt(bytesList.Count - 1);
+                    return result;
+                }
+            }
+            else
+            {
+                buffers[power] = new List<byte[]>();
+            }
+
+            arrayAllocatedCounter++;
+            return new byte[arraySize];
+        }
+
+        /// <summary>
+        /// Clear an array and return it to the pool
+        /// </summary>
+        internal void Return(byte[] arr)
+        {
+            if (arr.Length == 0)
+            {
+                return;
+            }
+
+            int arrLength = arr.Length;
+            Array.Clear(arr, 0, arrLength);
+            int power = CalculateBucketIndex(arrLength);
+            buffers[power].Add(arr);
+            
+            arrayReturnedCounter++;
+        }
+
+        /// <summary>
+        /// Clear the pool
+        /// </summary>
+        internal void ClearPool()
+        {
+            buffers.Clear();
+        }
+        
+        internal int GetNumberOfCurrentArraysInPool()
+        {
+            return buffers.Sum(bucket => bucket.Value.Count);
+        }
+
+        private static int CalculateBucketIndex(int arrLength)
+        {
+            return (int) Math.Ceiling(Math.Log(arrLength, 2.0));
+        }
+    }
+}

--- a/EsentInterop/RetrieveColumnHelpers.cs
+++ b/EsentInterop/RetrieveColumnHelpers.cs
@@ -288,6 +288,42 @@ namespace Microsoft.Isam.Esent.Interop
         /// <summary>
         /// Retrieves a single column value from the current record. The record is that
         /// record associated with the index entry at the current position of the cursor.
+        /// Alternatively, this function can retrieve a column from a record being created
+        /// in the cursor copy buffer. This function can also retrieve column data from an
+        /// index entry that references the current record. In addition to retrieving the
+        /// actual column value, JetRetrieveColumn can also be used to retrieve the size
+        /// of a column, before retrieving the column data itself so that application
+        /// buffers can be sized appropriately.
+        /// </summary>
+        /// <param name="sesid">The session to use.</param>
+        /// <param name="tableid">The cursor to retrieve the column from.</param>
+        /// <param name="columnid">The columnid to retrieve.</param>
+        /// <param name="data">The data buffer to be retrieved into.</param>
+        /// <param name="dataSize">The size of the data buffer.</param>
+        /// <param name="actualDataSize">Returns the actual size of the data buffer.</param>         
+        /// <param name="grbit">Retrieve column options.</param>
+        /// <param name="retinfo">
+        /// If pretinfo is give as NULL then the function behaves as though an itagSequence
+        /// of 1 and an ibLongValue of 0 (zero) were given. This causes column retrieval to
+        /// retrieve the first value of a multi-valued column, and to retrieve long data at
+        /// offset 0 (zero).
+        /// </param>
+        /// <returns>The data retrieved from the column. Null if the column is null.</returns>
+        public static JET_wrn RetrieveColumn(
+            JET_SESID sesid, JET_TABLEID tableid, JET_COLUMNID columnid, byte[] data, int dataSize, out int actualDataSize, RetrieveColumnGrbit grbit, JET_RETINFO retinfo)
+        {
+            // We cannot support this request when there is no way to indicate that a column reference is returned.
+            if ((grbit & (RetrieveColumnGrbit)0x00020000) != 0)  // UnpublishedGrbits.RetrieveAsRefIfNotInRecord
+            {
+                throw new EsentInvalidGrbitException();
+            }
+            
+            return JetRetrieveColumn(sesid, tableid, columnid, data, dataSize, out actualDataSize, grbit, retinfo);
+        }
+
+        /// <summary>
+        /// Retrieves a single column value from the current record. The record is that
+        /// record associated with the index entry at the current position of the cursor.
         /// </summary>
         /// <param name="sesid">The session to use.</param>
         /// <param name="tableid">The cursor to retrieve the column from.</param>

--- a/EsentInterop/SetColumnHelpers.cs
+++ b/EsentInterop/SetColumnHelpers.cs
@@ -150,13 +150,28 @@ namespace Microsoft.Isam.Esent.Interop
         /// <param name="grbit">SetColumn options.</param>
         public static void SetColumn(JET_SESID sesid, JET_TABLEID tableid, JET_COLUMNID columnid, byte[] data, SetColumnGrbit grbit)
         {
+            int dataLength = (null == data) ? 0 : data.Length;
+            SetColumn(sesid, tableid, columnid, data, dataLength, grbit);
+        }
+        
+        /// <summary>
+        /// Modifies a single column value in a modified record to be inserted or to
+        /// update the current record.
+        /// </summary>
+        /// <param name="sesid">The session to use.</param>
+        /// <param name="tableid">The cursor to update. An update should be prepared.</param>
+        /// <param name="columnid">The columnid to set.</param>
+        /// <param name="data">The data to set.</param>
+        /// <param name="dataSize">The size of data to set.</param>
+        /// <param name="grbit">SetColumn options.</param>
+        public static void SetColumn(JET_SESID sesid, JET_TABLEID tableid, JET_COLUMNID columnid, byte[] data, int dataSize, SetColumnGrbit grbit)
+        {
             if ((null != data) && (0 == data.Length))
             {
                 grbit |= SetColumnGrbit.ZeroLength;
             }
 
-            int dataLength = (null == data) ? 0 : data.Length;
-            JetSetColumn(sesid, tableid, columnid, data, dataLength, grbit, null);
+            JetSetColumn(sesid, tableid, columnid, data, dataSize, grbit, null);
         }
 
         /// <summary>

--- a/EsentInterop/SetColumnHelpers.cs
+++ b/EsentInterop/SetColumnHelpers.cs
@@ -171,8 +171,17 @@ namespace Microsoft.Isam.Esent.Interop
                 grbit |= SetColumnGrbit.ZeroLength;
             }
 
-            int dataLength = (null == data) ? 0 : dataSize;
-            JetSetColumn(sesid, tableid, columnid, data, dataLength, grbit, null);
+            if (data == null && dataSize > 0)
+            {
+                throw new ArgumentException(string.Format("data is null, but dataSize is: {0}", dataSize));
+            }
+
+            if (data != null && data.Length < dataSize)
+            {
+                throw new ArgumentException(string.Format("data.Length is less, than dataSize: data.Length={0}, dataSize={1}", data.Length, dataSize));
+            }
+            
+            JetSetColumn(sesid, tableid, columnid, data, dataSize, grbit, null);
         }
 
         /// <summary>

--- a/EsentInterop/SetColumnHelpers.cs
+++ b/EsentInterop/SetColumnHelpers.cs
@@ -171,7 +171,8 @@ namespace Microsoft.Isam.Esent.Interop
                 grbit |= SetColumnGrbit.ZeroLength;
             }
 
-            JetSetColumn(sesid, tableid, columnid, data, dataSize, grbit, null);
+            int dataLength = (null == data) ? 0 : dataSize;
+            JetSetColumn(sesid, tableid, columnid, data, dataLength, grbit, null);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds an interface `IColumnConverter`, which allows to use a custom type as a `value` inside `PersistentDictionary`. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/ManagedEsent/pull/55)