### PR TITLE
fix(typo): Correct 'Currency not on a record' to 'Currently not on a …

### DIFF
--- a/EsentInterop/jet_err.cs
+++ b/EsentInterop/jet_err.cs
@@ -1724,7 +1724,7 @@ namespace Microsoft.Isam.Esent.Interop
         RecordNoCopy = -1602,
 
         /// <summary>
-        /// Currency not on a record
+        /// Currently not on a record
         /// </summary>
         NoCurrentRecord = -1603,
 


### PR DESCRIPTION
### Fix typo in EsentNoCurrentRecordException

This PR fixes a small typo in the exception message and XML documentation:

- Changed **"Currency not on a record"** → **"Currently not on a record"**  
- Updated both the exception constructor and the XML doc comment.

Closes #60

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/ManagedEsent/pull/63)